### PR TITLE
Refactor/tensor impl compare boundary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,18 @@ set(NFORGE_SRC
 	src/core/tensor_view.cpp
 	src/core/tensor_shape.cpp
 	src/backend/cpu/tensor_impl_CPU.cpp
+	src/ops/semantic/semantic.cpp
 )
 
 # Build as a dynamic library
 add_library(NForge SHARED ${NFORGE_SRC})
 
 # Include headers
-target_include_directories(NForge PUBLIC
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+target_include_directories(NForge 
+	PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	PRIVATE
+		${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
 # Enable testing

--- a/include/nforge/backend/cpu/tensor_impl_CPU.h
+++ b/include/nforge/backend/cpu/tensor_impl_CPU.h
@@ -5,60 +5,53 @@
 #include "nforge/core/tensor_shape.h"
 
 class Tensor::CPUImpl : public Tensor::Impl {
-public:
-	CPUImpl(const Tensor::Shape &shape);
-	CPUImpl(const Tensor::Shape &shape, float value);
-	~CPUImpl();
+   public:
+    CPUImpl(const Tensor::Shape& shape);
+    CPUImpl(const Tensor::Shape& shape, float value);
+    ~CPUImpl();
 
-	// Fill functions
-	void fillAll(float value) override;
-	void fillRand() override;
+    // Fill functions
+    void fillAll(float value) override;
+    void fillRand() override;
 
+    // Printing
+    void print() const override;
+    void print(const std::vector<size_t>& position) const override;
 
-	// Printing
-	void print() const override;
-	void print(const std::vector<size_t> &position) const override;
-
-
-	// Tensor shape
+    // Tensor shape
     size_t numElements() const override;
     Tensor::Shape shape() const override;
 
-
-	// Data transforms
+    // Data transforms
     const float* data() const override;
     std::vector<float> toVector() const override;
-	std::string toString() const override;
+    std::string toString() const override;
 
-	std::unique_ptr<Tensor::Impl> clone() const override;
-
+    std::unique_ptr<Tensor::Impl> clone() const override;
 
     // Assignments and indexing
-	std::unique_ptr<Tensor::Impl> get(size_t idx) const override;
-	void set(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) override;
+    std::unique_ptr<Tensor::Impl> get(size_t idx) const override;
+    void set(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) override;
 
+    // Comparisons
+    bool compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
 
-	// Comparisons
-	bool compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
+    // Element wise binary tensor operations
+    std::unique_ptr<Tensor::Impl> add(const Tensor::Impl& other) const override;
+    std::unique_ptr<Tensor::Impl> sub(const Tensor::Impl& other) const override;
+    std::unique_ptr<Tensor::Impl> mul(const Tensor::Impl& other) const override;
+    std::unique_ptr<Tensor::Impl> div(const Tensor::Impl& other) const override;
 
-
-	// Element wise binary tensor operations
-	std::unique_ptr<Tensor::Impl> add(const Tensor::Impl &other) const override;
-	std::unique_ptr<Tensor::Impl> sub(const Tensor::Impl &other) const override;
-	std::unique_ptr<Tensor::Impl> mul(const Tensor::Impl &other) const override;
-	std::unique_ptr<Tensor::Impl> div(const Tensor::Impl &other) const override;
-
-
-	// Element wise binary tensor-scalar operations
+    // Element wise binary tensor-scalar operations
     // Requires the passed Tensor::Impl to be a scalar
-	std::unique_ptr<Tensor::Impl> addScalar(const Tensor::Impl& scalar) const override;
-	std::unique_ptr<Tensor::Impl> subScalar(const Tensor::Impl& scalar) const override;
-	std::unique_ptr<Tensor::Impl> mulScalar(const Tensor::Impl& scalar) const override;
-	std::unique_ptr<Tensor::Impl> divScalar(const Tensor::Impl& scalar) const override;
+    std::unique_ptr<Tensor::Impl> addScalar(const Tensor::Impl& scalar) const override;
+    std::unique_ptr<Tensor::Impl> subScalar(const Tensor::Impl& scalar) const override;
+    std::unique_ptr<Tensor::Impl> mulScalar(const Tensor::Impl& scalar) const override;
+    std::unique_ptr<Tensor::Impl> divScalar(const Tensor::Impl& scalar) const override;
 
-private:
-	Tensor::Shape m_shape;
-	std::vector<float> m_data;
+   private:
+    Tensor::Shape m_shape;
+    std::vector<float> m_data;
 };
 
-#endif // TENSOR_IMPL_CPU_H
+#endif  // TENSOR_IMPL_CPU_H

--- a/include/nforge/backend/cpu/tensor_impl_CPU.h
+++ b/include/nforge/backend/cpu/tensor_impl_CPU.h
@@ -19,11 +19,11 @@ class Tensor::CPUImpl : public Tensor::Impl {
     void print(const std::vector<size_t>& position) const override;
 
     // Tensor shape
-    size_t numElements() const override;
-    Tensor::Shape shape() const override;
+    size_t getNumElements() const override;
+    Tensor::Shape getShape() const override;
 
     // Data transforms
-    const float* data() const override;
+    float* dataPtr() const;
     std::vector<float> toVector() const override;
     std::string toString() const override;
 
@@ -37,17 +37,17 @@ class Tensor::CPUImpl : public Tensor::Impl {
     bool compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
 
     // Element wise binary tensor operations
-    std::unique_ptr<Tensor::Impl> add(const Tensor::Impl& other) const override;
-    std::unique_ptr<Tensor::Impl> sub(const Tensor::Impl& other) const override;
-    std::unique_ptr<Tensor::Impl> mul(const Tensor::Impl& other) const override;
-    std::unique_ptr<Tensor::Impl> div(const Tensor::Impl& other) const override;
+    std::unique_ptr<Tensor::Impl> add(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> sub(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> mul(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> div(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
 
     // Element wise binary tensor-scalar operations
-    // Requires the passed Tensor::Impl to be a scalar
-    std::unique_ptr<Tensor::Impl> addScalar(const Tensor::Impl& scalar) const override;
-    std::unique_ptr<Tensor::Impl> subScalar(const Tensor::Impl& scalar) const override;
-    std::unique_ptr<Tensor::Impl> mulScalar(const Tensor::Impl& scalar) const override;
-    std::unique_ptr<Tensor::Impl> divScalar(const Tensor::Impl& scalar) const override;
+	// Requires  rhs to be a scalar
+    std::unique_ptr<Tensor::Impl> addScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> subScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> mulScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> divScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const override;
 
    private:
     Tensor::Shape m_shape;

--- a/include/nforge/backend/cpu/tensor_impl_CPU.h
+++ b/include/nforge/backend/cpu/tensor_impl_CPU.h
@@ -31,27 +31,35 @@ class Tensor::CPUImpl : public Tensor::Impl {
 
     // Assignments and indexing
     std::unique_ptr<Tensor::Impl> get(size_t idx) const override;
-    void set(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) override;
+    void set(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) override;
 
     // Comparisons
-    bool compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
+    bool compare(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) const override;
 
     // Element wise binary tensor operations
-    std::unique_ptr<Tensor::Impl> add(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
-    std::unique_ptr<Tensor::Impl> sub(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
-    std::unique_ptr<Tensor::Impl> mul(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
-    std::unique_ptr<Tensor::Impl> div(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> add(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> sub(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> mul(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> div(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) const override;
 
     // Element wise binary tensor-scalar operations
 	// Requires  rhs to be a scalar
-    std::unique_ptr<Tensor::Impl> addScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const override;
-    std::unique_ptr<Tensor::Impl> subScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const override;
-    std::unique_ptr<Tensor::Impl> mulScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const override;
-    std::unique_ptr<Tensor::Impl> divScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> addScalar(size_t lhsOffset, const Tensor::Impl* rhs, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> subScalar(size_t lhsOffset, const Tensor::Impl* rhs, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> mulScalar(size_t lhsOffset, const Tensor::Impl* rhs, size_t count) const override;
+    std::unique_ptr<Tensor::Impl> divScalar(size_t lhsOffset, const Tensor::Impl* rhs, size_t count) const override;
 
    private:
     Tensor::Shape m_shape;
     std::vector<float> m_data;
+    
+    // res[i] = lhs[i] + scalar
+    template <typename ScalarOp>
+    std::unique_ptr<Tensor::Impl> applyBinaryScalarOp(size_t lhsOffset, const Tensor::Impl* rhs, size_t count, ScalarOp scalarOp) const;
+
+    // res[i] = lhs[i] + rhs[i]
+    template <typename BinaryOp>
+    std::unique_ptr<Tensor::Impl> applyBinaryOp(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count, BinaryOp binaryOp) const;
 };
 
 #endif  // TENSOR_IMPL_CPU_H

--- a/include/nforge/backend/cpu/tensor_impl_CPU.h
+++ b/include/nforge/backend/cpu/tensor_impl_CPU.h
@@ -35,16 +35,11 @@ public:
 
     // Assignments and indexing
 	std::unique_ptr<Tensor::Impl> get(size_t idx) const override;
-	void set(const std::vector<size_t> &position, const Tensor::Impl &other) override;
-	void set(const std::vector<size_t> &position, const Tensor::Impl &other, const std::vector<size_t> &otherPosition) override;
+	void set(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) override;
 
 
 	// Comparisons
-	bool compare(const std::vector<size_t> &position, const Tensor::Impl &other) const override;
-	bool compare(const std::vector<size_t> &position, const Tensor::Impl &other, const std::vector<size_t> &otherPosition) const override;
-
-	bool operator==(const Tensor::Impl &other) const override;
-	bool operator!=(const Tensor::Impl &other) const override;
+	bool compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const override;
 
 
 	// Element wise binary tensor operations

--- a/include/nforge/backend/cpu/tensor_impl_CPU.h
+++ b/include/nforge/backend/cpu/tensor_impl_CPU.h
@@ -30,7 +30,6 @@ class Tensor::CPUImpl : public Tensor::Impl {
     std::unique_ptr<Tensor::Impl> clone() const override;
 
     // Assignments and indexing
-    std::unique_ptr<Tensor::Impl> get(size_t idx) const override;
     void set(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) override;
 
     // Comparisons

--- a/include/nforge/backend/tensor_impl.h
+++ b/include/nforge/backend/tensor_impl.h
@@ -28,24 +28,24 @@ class Tensor::Impl {
 
     // Assignments and indexing
     virtual std::unique_ptr<Tensor::Impl> get(size_t idx) const = 0;
-    virtual void set(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) = 0;
+    virtual void set(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) = 0;
 
     // Comparisons
     // Block comparisons
-    virtual bool compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
+    virtual bool compare(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) const = 0;
 
     // Element wise binary tensor operations
-    virtual std::unique_ptr<Tensor::Impl> add(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> sub(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> mul(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> div(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> add(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> sub(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> mul(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> div(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) const = 0;
 
     // Element wise binary tensor-scalar operations
     // Requires rhs to be a scalar
-    virtual std::unique_ptr<Tensor::Impl> addScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> subScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> mulScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> divScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> addScalar(size_t lhsOffset, const Tensor::Impl* rhs, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> subScalar(size_t lhsOffset, const Tensor::Impl* rhs, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> mulScalar(size_t lhsOffset, const Tensor::Impl* rhs, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> divScalar(size_t lhsOffset, const Tensor::Impl* rhs, size_t count) const = 0;
 };
 
 #endif  // TENSOR_IMPL_H

--- a/include/nforge/backend/tensor_impl.h
+++ b/include/nforge/backend/tensor_impl.h
@@ -33,18 +33,12 @@ public:
 
     // Assignments and indexing
     virtual std::unique_ptr<Tensor::Impl> get(size_t idx) const = 0;
-    virtual void set(const std::vector<size_t>& position, const Tensor::Impl& other) = 0;
-    virtual void set(const std::vector<size_t>& position, const Tensor::Impl& other, const std::vector<size_t>& otherIdx) = 0;
+	virtual void set(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) = 0;
 
 
     // Comparisons
     // Block comparisons
-    virtual bool compare(const std::vector<size_t>& position, const Tensor::Impl& other) const = 0;
-    virtual bool compare(const std::vector<size_t>& position, const Tensor::Impl& other, const std::vector<size_t>& otherIdx) const = 0;
-
-    // Tensor comparisons
-    virtual bool operator==(const Tensor::Impl& other) const = 0;
-    virtual bool operator!=(const Tensor::Impl& other) const = 0;
+	virtual bool compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
 
 
 	// Element wise binary tensor operations

--- a/include/nforge/backend/tensor_impl.h
+++ b/include/nforge/backend/tensor_impl.h
@@ -27,7 +27,6 @@ class Tensor::Impl {
     virtual std::unique_ptr<Tensor::Impl> clone() const = 0;
 
     // Assignments and indexing
-    virtual std::unique_ptr<Tensor::Impl> get(size_t idx) const = 0;
     virtual void set(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) = 0;
 
     // Comparisons

--- a/include/nforge/backend/tensor_impl.h
+++ b/include/nforge/backend/tensor_impl.h
@@ -4,56 +4,49 @@
 #include "nforge/core/tensor.h"
 
 class Tensor::Impl {
-public:
+   public:
     Impl() = default;
     virtual ~Impl() = default;
 
     // Fill functions
-	virtual void fillAll(float value) = 0;
+    virtual void fillAll(float value) = 0;
     virtual void fillRand() = 0;
 
-    
     // Printing
-	virtual void print() const = 0;
+    virtual void print() const = 0;
     virtual void print(const std::vector<size_t>& position) const = 0;
-
 
     // Tensor shape
     virtual size_t numElements() const = 0;
     virtual Tensor::Shape shape() const = 0;
 
-
     // Data transforms
     virtual const float* data() const = 0;
     virtual std::vector<float> toVector() const = 0;
-	virtual std::string toString() const = 0;
+    virtual std::string toString() const = 0;
 
     virtual std::unique_ptr<Tensor::Impl> clone() const = 0;
 
-
     // Assignments and indexing
     virtual std::unique_ptr<Tensor::Impl> get(size_t idx) const = 0;
-	virtual void set(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) = 0;
-
+    virtual void set(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) = 0;
 
     // Comparisons
     // Block comparisons
-	virtual bool compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
+    virtual bool compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
 
+    // Element wise binary tensor operations
+    virtual std::unique_ptr<Tensor::Impl> add(const Tensor::Impl& other) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> sub(const Tensor::Impl& other) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> mul(const Tensor::Impl& other) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> div(const Tensor::Impl& other) const = 0;
 
-	// Element wise binary tensor operations
-	virtual std::unique_ptr<Tensor::Impl> add(const Tensor::Impl& other) const = 0;
-	virtual std::unique_ptr<Tensor::Impl> sub(const Tensor::Impl& other) const = 0;
-	virtual std::unique_ptr<Tensor::Impl> mul(const Tensor::Impl& other) const = 0;
-	virtual std::unique_ptr<Tensor::Impl> div(const Tensor::Impl& other) const = 0;
-
-
-	// Element wise binary tensor-scalar operations
+    // Element wise binary tensor-scalar operations
     // Requires the passed Tensor::Impl to be a scalar
-	virtual std::unique_ptr<Tensor::Impl> addScalar(const Tensor::Impl& other) const = 0;
-	virtual std::unique_ptr<Tensor::Impl> subScalar(const Tensor::Impl& other) const = 0;
-	virtual std::unique_ptr<Tensor::Impl> mulScalar(const Tensor::Impl& other) const = 0;
-	virtual std::unique_ptr<Tensor::Impl> divScalar(const Tensor::Impl& other) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> addScalar(const Tensor::Impl& other) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> subScalar(const Tensor::Impl& other) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> mulScalar(const Tensor::Impl& other) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> divScalar(const Tensor::Impl& other) const = 0;
 };
 
-#endif // TENSOR_IMPL_H
+#endif  // TENSOR_IMPL_H

--- a/include/nforge/backend/tensor_impl.h
+++ b/include/nforge/backend/tensor_impl.h
@@ -17,11 +17,10 @@ class Tensor::Impl {
     virtual void print(const std::vector<size_t>& position) const = 0;
 
     // Tensor shape
-    virtual size_t numElements() const = 0;
-    virtual Tensor::Shape shape() const = 0;
+    virtual size_t getNumElements() const = 0;
+    virtual Tensor::Shape getShape() const = 0;
 
     // Data transforms
-    virtual const float* data() const = 0;
     virtual std::vector<float> toVector() const = 0;
     virtual std::string toString() const = 0;
 
@@ -36,17 +35,17 @@ class Tensor::Impl {
     virtual bool compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
 
     // Element wise binary tensor operations
-    virtual std::unique_ptr<Tensor::Impl> add(const Tensor::Impl& other) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> sub(const Tensor::Impl& other) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> mul(const Tensor::Impl& other) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> div(const Tensor::Impl& other) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> add(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> sub(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> mul(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> div(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const = 0;
 
     // Element wise binary tensor-scalar operations
-    // Requires the passed Tensor::Impl to be a scalar
-    virtual std::unique_ptr<Tensor::Impl> addScalar(const Tensor::Impl& other) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> subScalar(const Tensor::Impl& other) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> mulScalar(const Tensor::Impl& other) const = 0;
-    virtual std::unique_ptr<Tensor::Impl> divScalar(const Tensor::Impl& other) const = 0;
+    // Requires rhs to be a scalar
+    virtual std::unique_ptr<Tensor::Impl> addScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> subScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> mulScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const = 0;
+    virtual std::unique_ptr<Tensor::Impl> divScalar(size_t lhsOffset, const Tensor::Impl& rhs, size_t count) const = 0;
 };
 
 #endif  // TENSOR_IMPL_H

--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -46,6 +46,9 @@ public:
 	// Returns the data of the tensor as a string
     std::string backendString() const;
 
+    // Returns backend enum
+    Backend getBackend() const;
+
 	// Returns the data of the tensor as a string
 	std::string dataString() const;
     

--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -9,7 +9,7 @@
 
 #define LOG(x) std::cerr
 
-enum class Backend { CPU };
+enum class Backend { CPU, CUDA };
 
 class Tensor {
 public:

--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -40,7 +40,7 @@ public:
     void print() const; 
     void print(const std::vector<size_t>& position) const;
 
-    // Returns the shape of the tensor as a string
+    // Returns the shape of the tensor
 	Tensor::Shape shape() const;
 
 	// Returns the data of the tensor as a string

--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -1,61 +1,62 @@
 #ifndef TENSOR_H
 #define TENSOR_H
 
-#include <vector>
-#include <string>
+#include <cassert>
 #include <iostream>
 #include <memory>
-#include <cassert>
+#include <string>
+#include <vector>
 
-#define LOG(x) std::cerr
-
-enum class Backend { CPU, CUDA };
+enum class Backend {
+    CPU,
+    CUDA
+};
 
 class Tensor {
-public:
+   public:
     class Impl;
     class CPUImpl;
-    
+
     class View;
     class Shape;
 
-public:
+   public:
     Tensor(const Tensor::Shape& shape, Backend backend = Backend::CPU);
     Tensor(const Tensor::Shape& shape, float value, Backend backend = Backend::CPU);
     Tensor(float value, Backend backend = Backend::CPU);
     Tensor(const Tensor& tensor);
     Tensor(std::unique_ptr<Tensor::Impl> impl, Backend backend = Backend::CPU);
     ~Tensor();
-    
-    // Move data between backends
+
+    // Switch between backends
     void to(Backend newBackend);
-    
+
     // Fill all elements with a value
     void fillAll(float value);
-    
+
     // Fill all elements with uniform real values in [-1, 1]
     void fillRand();
-    
+
     // Print the tensor data
-    void print() const; 
+    void print() const;
     void print(const std::vector<size_t>& position) const;
 
     // Returns the shape of the tensor
-	Tensor::Shape shape() const;
+    Tensor::Shape getShape() const;
 
-	// Returns the data of the tensor as a string
-    std::string backendString() const;
+    // Returns the data of the tensor as a string
+    std::string getBackendString() const;
 
     // Returns backend enum
     Backend getBackend() const;
 
-	// Returns the data of the tensor as a string
-	std::string dataString() const;
-    
+    // Returns the data of the tensor as a string
+    std::string getDataString() const;
+
     // Returns the number of elements in the tensor
-    size_t numElements() const;
-    
-    // Returns tensor data as a vector 
+    size_t getNumElements() const;
+
+    // Returns tensor data as a vector
     std::vector<float> toVector() const;
 
     // Set the specified block to another tensor
@@ -64,7 +65,7 @@ public:
 
     bool compare(const Tensor& other) const;
     bool compare(const Tensor::View& other) const;
-    
+
     // Compare the specified block to another tensor
     bool compare(const std::vector<size_t>& position, const Tensor& other) const;
     bool compare(const std::vector<size_t>& position, const Tensor::View& other) const;
@@ -84,13 +85,13 @@ public:
     bool operator!=(const Tensor& other) const;
     bool operator!=(const Tensor::View& other) const;
 
-private:
+   private:
     Backend m_backend;
     std::unique_ptr<Impl> m_impl;
 };
 
+#include "nforge/backend/tensor_impl.h"
 #include "nforge/core/tensor_shape.h"
 #include "nforge/core/tensor_view.h"
-#include "nforge/backend/tensor_impl.h"
 
-#endif // TENSOR_H
+#endif  // TENSOR_H

--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -24,7 +24,7 @@ public:
     Tensor(const Tensor::Shape& shape, float value, Backend backend = Backend::CPU);
     Tensor(float value, Backend backend = Backend::CPU);
     Tensor(const Tensor& tensor);
-    Tensor(std::unique_ptr<Tensor::Impl> impl);
+    Tensor(std::unique_ptr<Tensor::Impl> impl, Backend backend = Backend::CPU);
     ~Tensor();
     
     // Move data between backends
@@ -62,6 +62,9 @@ public:
     void set(const std::vector<size_t>& position, const Tensor& other);
     void set(const std::vector<size_t>& position, const Tensor::View& other);
 
+    bool compare(const Tensor& other) const;
+    bool compare(const Tensor::View& other) const;
+    
     // Compare the specified block to another tensor
     bool compare(const std::vector<size_t>& position, const Tensor& other) const;
     bool compare(const std::vector<size_t>& position, const Tensor::View& other) const;
@@ -77,7 +80,9 @@ public:
     Tensor operator=(const Tensor& other);
 
     bool operator==(const Tensor& other) const;
+    bool operator==(const Tensor::View& other) const;
     bool operator!=(const Tensor& other) const;
+    bool operator!=(const Tensor::View& other) const;
 
 private:
     Backend m_backend;

--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -88,6 +88,10 @@ class Tensor {
    private:
     Backend m_backend;
     std::unique_ptr<Impl> m_impl;
+
+    // used in template for all the binary operations
+    template <typename EqualOp, typename ScalarOp>
+    Tensor applyBinaryOp(const Tensor& rhs, const std::string& opName, EqualOp equalOp, ScalarOp scalarOp) const;
 };
 
 #include "nforge/backend/tensor_impl.h"

--- a/include/nforge/core/tensor_shape.h
+++ b/include/nforge/core/tensor_shape.h
@@ -1,24 +1,24 @@
 #ifndef TENSOR_SHAPE_H
 #define TENSOR_SHAPE_H
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "nforge/core/tensor.h"
 
 class Tensor::Shape {
-public:
+   public:
     Shape() = default;
     Shape(const std::vector<size_t>& dims);
     Shape(const std::initializer_list<size_t>& dims);
 
-    bool operator==(const Tensor::Shape &other) const;
-    bool operator!=(const Tensor::Shape &other) const;
+    bool operator==(const Tensor::Shape& other) const;
+    bool operator!=(const Tensor::Shape& other) const;
 
     // Access and properties
     size_t getNumDims() const;
     size_t getNumElements() const;
-    size_t getDim(size_t idx) const; // return size of indexed dimension
+    size_t getDim(size_t idx) const;  // return size of indexed dimension
     bool isScalar() const;
 
     Tensor::Shape operator[](size_t index) const;
@@ -33,8 +33,8 @@ public:
     std::vector<size_t> toVector() const;
     std::vector<size_t> withoutTrailingOnes() const;
 
-private:
+   private:
     std::vector<size_t> m_dimensions;
 };
 
-#endif // TENSOR_SHAPE_H
+#endif  // TENSOR_SHAPE_H

--- a/include/nforge/core/tensor_shape.h
+++ b/include/nforge/core/tensor_shape.h
@@ -16,14 +16,17 @@ public:
     bool operator!=(const Tensor::Shape &other) const;
 
     // Access and properties
-    size_t dims() const;
-    size_t operator[](size_t index) const;
-    size_t totalSize() const;
+    size_t getNumDims() const;
+    size_t getNumElements() const;
+    size_t getDim(size_t idx) const; // return size of indexed dimension
     bool isScalar() const;
+
+    Tensor::Shape operator[](size_t index) const;
+    Tensor::Shape operator[](const std::vector<size_t>& position) const;
 
     // Shape modifications
     Tensor::Shape removeLeadingDimension() const;
-    Tensor::Shape slice(size_t start, size_t end) const;
+    Tensor::Shape getSlice(size_t start, size_t end) const;
 
     // Utility methods
     std::string toString() const;

--- a/include/nforge/core/tensor_view.h
+++ b/include/nforge/core/tensor_view.h
@@ -9,8 +9,17 @@ public:
 
     void print() const;
 
+    // refrenced tensor
     Tensor& getParent() const;
+
+    // position of this view in the tensor it refrences
     std::vector<size_t> getPosition() const;
+
+    // number of elements preceding this view
+    size_t getOffset() const;
+    
+    // shape of the view
+    Tensor::Shape getShape() const;
     
     Tensor operator=(const Tensor& other);
     Tensor operator=(const Tensor::View& other);

--- a/include/nforge/core/tensor_view.h
+++ b/include/nforge/core/tensor_view.h
@@ -6,6 +6,7 @@
 class Tensor::View {
 public:
     View(Tensor& parent, const std::vector<size_t>& index);
+    View(const Tensor& parent);
 
     void print() const;
 

--- a/include/nforge/core/tensor_view.h
+++ b/include/nforge/core/tensor_view.h
@@ -4,7 +4,7 @@
 #include "nforge/core/tensor.h"
 
 class Tensor::View {
-public:
+   public:
     View(Tensor& parent, const std::vector<size_t>& index);
     View(const Tensor& parent);
 
@@ -18,10 +18,10 @@ public:
 
     // number of elements preceding this view
     size_t getOffset() const;
-    
+
     // shape of the view
     Tensor::Shape getShape() const;
-    
+
     Tensor operator=(const Tensor& other);
     Tensor operator=(const Tensor::View& other);
     Tensor::View operator[](size_t idx) const;
@@ -31,10 +31,10 @@ public:
 
     bool operator!=(const Tensor& other) const;
     bool operator!=(const Tensor::View& other) const;
-    
-private:
+
+   private:
     Tensor& m_parent;
     std::vector<size_t> m_position;
 };
 
-#endif // TENSOR_VIEW_H
+#endif  // TENSOR_VIEW_H

--- a/src/backend/cpu/tensor_impl_CPU.cpp
+++ b/src/backend/cpu/tensor_impl_CPU.cpp
@@ -1,297 +1,292 @@
-#include "nforge/core/tensor.h"
 #include "nforge/backend/cpu/tensor_impl_CPU.h"
 
 #include <algorithm>
 #include <random>
 
-Tensor::CPUImpl::CPUImpl(const Tensor::Shape& shape) 
-	: m_shape(shape) {
-	m_data.assign(m_shape.getNumElements(), 0.0f);
+#include "nforge/core/tensor.h"
+
+Tensor::CPUImpl::CPUImpl(const Tensor::Shape& shape)
+    : m_shape(shape) {
+    m_data.assign(m_shape.getNumElements(), 0.0f);
 }
 
-Tensor::CPUImpl::CPUImpl(const Tensor::Shape& shape, float value) 
-	: m_shape(shape) {
-	m_data.assign(m_shape.getNumElements(), value);
+Tensor::CPUImpl::CPUImpl(const Tensor::Shape& shape, float value)
+    : m_shape(shape) {
+    m_data.assign(m_shape.getNumElements(), value);
 }
 
 Tensor::CPUImpl::~CPUImpl() {
-	m_data.clear();
-	m_data.shrink_to_fit();
+    m_data.clear();
+    m_data.shrink_to_fit();
 }
 
 void Tensor::CPUImpl::fillAll(float value) {
-	m_data.assign(m_data.size(), value);
+    m_data.assign(m_data.size(), value);
 }
 
 void Tensor::CPUImpl::fillRand() {
-	static std::mt19937 engine(std::random_device{}());
+    static std::mt19937 engine(std::random_device{}());
     static std::uniform_real_distribution<double> dist(-1.0, 1.0);
 
-	auto gen = [&]() {
-		return dist(engine);
-	};
+    auto gen = [&]() {
+        return dist(engine);
+    };
 
-	std::generate(m_data.begin(), m_data.end(), gen);
+    std::generate(m_data.begin(), m_data.end(), gen);
 }
 
 void Tensor::CPUImpl::print() const {
-	std::cout << "====================\n";
-	std::cout << "Tensor[CPU], Data:\n";
+    std::cout << "====================\n";
+    std::cout << "Tensor[CPU], Data:\n";
 
+    std::vector<size_t> numElementsInDimsCurAndBelow(m_shape.getNumDims(), 1);
+    for (int i = static_cast<int>(m_shape.getNumDims()) - 1; i >= 0; i--) {
+        numElementsInDimsCurAndBelow[i] *= m_shape.getDim(i);
+        if (i != static_cast<int>(m_shape.getNumDims()) - 1) {
+            numElementsInDimsCurAndBelow[i] *= numElementsInDimsCurAndBelow[i + 1];
+        }
+    }
 
-	std::vector<size_t> numElementsInDimsCurAndBelow(m_shape.getNumDims(), 1);
-	for (int i = static_cast<int>(m_shape.getNumDims()) - 1; i >= 0; i--) {
-		numElementsInDimsCurAndBelow[i] *= m_shape.getDim(i);
-		if (i != static_cast<int>(m_shape.getNumDims()) - 1) {
-			numElementsInDimsCurAndBelow[i] *= numElementsInDimsCurAndBelow[i + 1];
-		}
-	}
+    for (size_t i = 0; i < m_data.size(); i++) {
+        std::cout << m_data[i] << " ";
+        for (size_t j = 0; j < m_shape.getNumDims(); j++) {
+            // if element count of the block represented by suffix starting at j, divides i, then print a new line
+            if (i % numElementsInDimsCurAndBelow[j] == numElementsInDimsCurAndBelow[j] - 1 && i != m_data.size() - 1) {
+                std::cout << "\n";
+            }
+        }
+    }
 
-	
-	for (size_t i = 0; i < m_data.size(); i++) {
-		std::cout << m_data[i] << " ";
-		for (size_t j = 0; j < m_shape.getNumDims(); j++) {
-			// if element count of the block represented by suffix starting at j, divides i, then print a new line
-			if (i % numElementsInDimsCurAndBelow[j] == numElementsInDimsCurAndBelow[j] - 1 && i != m_data.size() - 1) {
-				std::cout << "\n";
-			}
-		}
-	}
-
-	std::cout << "Shape: " << shape().toString() << "\n";
-	std::cout << "====================\n";
+    std::cout << "Shape: " << shape().toString() << "\n";
+    std::cout << "====================\n";
 }
 
 void Tensor::CPUImpl::print(const std::vector<size_t>& position) const {
-	std::cout << "====================\n";
-	std::cout << "Tensor[CPU], Data:\n";
+    std::cout << "====================\n";
+    std::cout << "Tensor[CPU], Data:\n";
 
-	std::vector<size_t> numElementsInDimsCurAndBelow(m_shape.getNumDims(), 1);
-	for (int i = static_cast<int>(m_shape.getNumDims()) - 1; i >= 0; i--) {
-		numElementsInDimsCurAndBelow[i] *= m_shape.getDim(i);
-		if (i != static_cast<int>(m_shape.getNumDims()) - 1) {
-			numElementsInDimsCurAndBelow[i] *= numElementsInDimsCurAndBelow[i + 1];
-		}
-	}
+    std::vector<size_t> numElementsInDimsCurAndBelow(m_shape.getNumDims(), 1);
+    for (int i = static_cast<int>(m_shape.getNumDims()) - 1; i >= 0; i--) {
+        numElementsInDimsCurAndBelow[i] *= m_shape.getDim(i);
+        if (i != static_cast<int>(m_shape.getNumDims()) - 1) {
+            numElementsInDimsCurAndBelow[i] *= numElementsInDimsCurAndBelow[i + 1];
+        }
+    }
 
-	size_t blockSize = m_shape.getSlice(position.size(), m_shape.getNumDims()).getNumElements();
+    size_t blockSize = m_shape.getSlice(position.size(), m_shape.getNumDims()).getNumElements();
 
-	size_t offsetCount = blockSize;
-	for (size_t i = 0; i < position.size(); i++) {
-		// if first slice in a dim
-		if (offsetCount == 0) {
-			offsetCount = blockSize;
-		}
+    size_t offsetCount = blockSize;
+    for (size_t i = 0; i < position.size(); i++) {
+        // if first slice in a dim
+        if (offsetCount == 0) {
+            offsetCount = blockSize;
+        }
 
-		offsetCount *= position[i];
-	}
+        offsetCount *= position[i];
+    }
 
-	for (size_t i = offsetCount; i < offsetCount + blockSize; i++) {
-		std::cout << m_data[i] << " ";
-		for (size_t j = 0; j < m_shape.getNumDims(); j++) {
-			if (i % numElementsInDimsCurAndBelow[j] == numElementsInDimsCurAndBelow[j] - 1 && i != offsetCount + blockSize - 1) {
-				std::cout << "\n";
-			}
-		}
-	}
-	std::cout << "\n";
+    for (size_t i = offsetCount; i < offsetCount + blockSize; i++) {
+        std::cout << m_data[i] << " ";
+        for (size_t j = 0; j < m_shape.getNumDims(); j++) {
+            if (i % numElementsInDimsCurAndBelow[j] == numElementsInDimsCurAndBelow[j] - 1 && i != offsetCount + blockSize - 1) {
+                std::cout << "\n";
+            }
+        }
+    }
+    std::cout << "\n";
 
-	std::cout << "Shape: " << m_shape.getSlice(position.size(), m_shape.getNumDims()).toString() << "\n";
-	std::cout << "====================\n";
+    std::cout << "Shape: " << m_shape.getSlice(position.size(), m_shape.getNumDims()).toString() << "\n";
+    std::cout << "====================\n";
 }
 
 Tensor::Shape Tensor::CPUImpl::shape() const {
-	return m_shape;
+    return m_shape;
 }
 
 std::string Tensor::CPUImpl::toString() const {
-	std::string out;
+    std::string out;
 
-	out += "{ ";
-	for (float element : m_data) {
-		out += std::to_string(element) + " ";
-	}
-	out += "}";
+    out += "{ ";
+    for (float element : m_data) {
+        out += std::to_string(element) + " ";
+    }
+    out += "}";
 
-	return out;
+    return out;
 }
 
 size_t Tensor::CPUImpl::numElements() const {
-	size_t numImpliedByShape = m_shape.getNumElements();
-	size_t numInContainer = m_data.size();
+    size_t numImpliedByShape = m_shape.getNumElements();
+    size_t numInContainer = m_data.size();
 
-	assert(numImpliedByShape == numInContainer);
-	
-	return numInContainer;
+    assert(numImpliedByShape == numInContainer);
+
+    return numInContainer;
 }
 
 std::vector<float> Tensor::CPUImpl::toVector() const {
-	return m_data;
+    return m_data;
 }
 
 const float* Tensor::CPUImpl::data() const {
-	return m_data.data();
+    return m_data.data();
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::clone() const {
-	return std::make_unique<CPUImpl>(*this);
+    return std::make_unique<CPUImpl>(*this);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::get(size_t idx) const {
-	// shape {3, 2, 5}
-	//[[[x, x, x, x, x], [x, x, x, x, x]], 
-	// [[x, x, x, x, x], [x, x, x, x, x]], 
-	// [[x, x, x, x, x], [x, x, x, x, x]]]
+    // shape {3, 2, 5}
+    //[[[x, x, x, x, x], [x, x, x, x, x]],
+    // [[x, x, x, x, x], [x, x, x, x, x]],
+    // [[x, x, x, x, x], [x, x, x, x, x]]]
 
-	if (m_shape.getNumDims() == 0) {
-		throw std::runtime_error("Can not index tensor of zero dimensions");
-		return std::unique_ptr<Tensor::Impl>(new Tensor::CPUImpl(*this));
-	}
+    if (m_shape.getNumDims() == 0) {
+        throw std::runtime_error("Can not index tensor of zero dimensions");
+        return std::unique_ptr<Tensor::Impl>(new Tensor::CPUImpl(*this));
+    }
 
-	if (m_shape.getNumDims() == 1 && m_shape.getDim(0) == 1) {
-		throw std::runtime_error("Can not index tensor of one dimension and one element");
-		return std::unique_ptr<Tensor::Impl>(new Tensor::CPUImpl(*this));
-	}
+    if (m_shape.getNumDims() == 1 && m_shape.getDim(0) == 1) {
+        throw std::runtime_error("Can not index tensor of one dimension and one element");
+        return std::unique_ptr<Tensor::Impl>(new Tensor::CPUImpl(*this));
+    }
 
-	Tensor::Shape newShape = m_shape.getSlice(1, m_shape.getNumDims());
-	Tensor::CPUImpl* results = new Tensor::CPUImpl(newShape);
+    Tensor::Shape newShape = m_shape.getSlice(1, m_shape.getNumDims());
+    Tensor::CPUImpl* results = new Tensor::CPUImpl(newShape);
 
-	size_t offset = newShape.getNumElements() * idx;
-	for (size_t i = 0; i < newShape.getNumElements(); i++) {
-		results->m_data[i] = m_data[i + offset];
-	}
+    size_t offset = newShape.getNumElements() * idx;
+    for (size_t i = 0; i < newShape.getNumElements(); i++) {
+        results->m_data[i] = m_data[i + offset];
+    }
 
-	return std::unique_ptr<Tensor::Impl>(results);
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 
 void Tensor::CPUImpl::set(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) {
-	const auto& o = static_cast<const Tensor::CPUImpl&>(rhs);
-	
-	float* a = m_data.data() + lhsOffset;
-	const float* b = rhs.data() + rhsOffset;
+    const auto& o = static_cast<const Tensor::CPUImpl&>(rhs);
 
-	for (size_t i = 0; i < count; i++) {
-		a[i] = b[i];
-	}
+    float* a = m_data.data() + lhsOffset;
+    const float* b = rhs.data() + rhsOffset;
+
+    for (size_t i = 0; i < count; i++) {
+        a[i] = b[i];
+    }
 }
 
 bool Tensor::CPUImpl::compare(size_t lhsOffset, const Tensor::Impl& rhs, size_t rhsOffset, size_t count) const {
-	const auto& o = static_cast<const Tensor::CPUImpl&>(rhs);
-	
-	const float* a = m_data.data() + lhsOffset;
-	const float* b = rhs.data() + rhsOffset;
+    const auto& o = static_cast<const Tensor::CPUImpl&>(rhs);
 
-	for (size_t i = 0; i < count; i++) {
-		if (a[i] != b[i]) return false;
-	}
+    const float* a = m_data.data() + lhsOffset;
+    const float* b = rhs.data() + rhsOffset;
 
-	return true;
+    for (size_t i = 0; i < count; i++) {
+        if (a[i] != b[i]) return false;
+    }
+
+    return true;
 }
-
 
 ///////////////////////////////////////////
 // Element wise binary tensor operations //
 ///////////////////////////////////////////
 
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::add(const Tensor::Impl& other) const {
-	Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
+    Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
 
-	const Tensor::CPUImpl* o = dynamic_cast<const Tensor::CPUImpl*>(&other);
+    const Tensor::CPUImpl* o = dynamic_cast<const Tensor::CPUImpl*>(&other);
 
-	for (size_t i = 0; i < m_data.size(); i++) {
-		results->m_data[i] = m_data[i] + o->m_data[i];
- 	}
+    for (size_t i = 0; i < m_data.size(); i++) {
+        results->m_data[i] = m_data[i] + o->m_data[i];
+    }
 
-	return std::unique_ptr<Tensor::Impl>(results);
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::sub(const Tensor::Impl& other) const {
-	Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
+    Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
 
-	const Tensor::CPUImpl* o = dynamic_cast<const Tensor::CPUImpl*>(&other);
+    const Tensor::CPUImpl* o = dynamic_cast<const Tensor::CPUImpl*>(&other);
 
-	for (size_t i = 0; i < m_data.size(); i++) {
-		results->m_data[i] = m_data[i] - o->m_data[i];
- 	}
+    for (size_t i = 0; i < m_data.size(); i++) {
+        results->m_data[i] = m_data[i] - o->m_data[i];
+    }
 
-	return std::unique_ptr<Tensor::Impl>(results);
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::mul(const Tensor::Impl& other) const {
-	Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
+    Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
 
-	const Tensor::CPUImpl* o = dynamic_cast<const Tensor::CPUImpl*>(&other);
+    const Tensor::CPUImpl* o = dynamic_cast<const Tensor::CPUImpl*>(&other);
 
-	for (size_t i = 0; i < m_data.size(); i++) {
-		results->m_data[i] = m_data[i] * o->m_data[i];
- 	}
+    for (size_t i = 0; i < m_data.size(); i++) {
+        results->m_data[i] = m_data[i] * o->m_data[i];
+    }
 
-	return std::unique_ptr<Tensor::Impl>(results);
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::div(const Tensor::Impl& other) const {
-	Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
+    Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
 
-	const Tensor::CPUImpl* o = dynamic_cast<const Tensor::CPUImpl*>(&other);
+    const Tensor::CPUImpl* o = dynamic_cast<const Tensor::CPUImpl*>(&other);
 
-	for (size_t i = 0; i < m_data.size(); i++) {
-		results->m_data[i] = m_data[i] / o->m_data[i];
- 	}
+    for (size_t i = 0; i < m_data.size(); i++) {
+        results->m_data[i] = m_data[i] / o->m_data[i];
+    }
 
-	return std::unique_ptr<Tensor::Impl>(results);
+    return std::unique_ptr<Tensor::Impl>(results);
 }
-
 
 //////////////////////////////////////////////////
 // Element wise binary tensor-scalar operations //
 //////////////////////////////////////////////////
 
-
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::addScalar(const Tensor::Impl& other) const {
-	Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
+    Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
 
-	float scalar = other.toVector()[0];
+    float scalar = other.toVector()[0];
 
-	for (size_t i = 0; i < m_data.size(); i++) {
-		results->m_data[i] = m_data[i] + scalar;
- 	}
+    for (size_t i = 0; i < m_data.size(); i++) {
+        results->m_data[i] = m_data[i] + scalar;
+    }
 
-	return std::unique_ptr<Tensor::Impl>(results);
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::subScalar(const Tensor::Impl& other) const {
-	Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
+    Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
 
-	float scalar = other.toVector()[0];
+    float scalar = other.toVector()[0];
 
-	for (size_t i = 0; i < m_data.size(); i++) {
-		results->m_data[i] = m_data[i] - scalar;
- 	}
+    for (size_t i = 0; i < m_data.size(); i++) {
+        results->m_data[i] = m_data[i] - scalar;
+    }
 
-	return std::unique_ptr<Tensor::Impl>(results);
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::mulScalar(const Tensor::Impl& other) const {
-	Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
+    Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
 
-	float scalar = other.toVector()[0];
+    float scalar = other.toVector()[0];
 
-	for (size_t i = 0; i < m_data.size(); i++) {
-		results->m_data[i] = m_data[i] * scalar;
- 	}
+    for (size_t i = 0; i < m_data.size(); i++) {
+        results->m_data[i] = m_data[i] * scalar;
+    }
 
-	return std::unique_ptr<Tensor::Impl>(results);
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::divScalar(const Tensor::Impl& other) const {
-	Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
+    Tensor::CPUImpl* results = new Tensor::CPUImpl(this->m_shape.toVector());
 
-	float scalar = other.toVector()[0];
+    float scalar = other.toVector()[0];
 
-	for (size_t i = 0; i < m_data.size(); i++) {
-		results->m_data[i] = m_data[i] / scalar;
- 	}
+    for (size_t i = 0; i < m_data.size(); i++) {
+        results->m_data[i] = m_data[i] / scalar;
+    }
 
-	return std::unique_ptr<Tensor::Impl>(results);
+    return std::unique_ptr<Tensor::Impl>(results);
 }
-

--- a/src/backend/cpu/tensor_impl_CPU.cpp
+++ b/src/backend/cpu/tensor_impl_CPU.cpp
@@ -136,33 +136,6 @@ std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::clone() const {
     return std::make_unique<CPUImpl>(*this);
 }
 
-std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::get(size_t idx) const {
-    // shape {3, 2, 5}
-    //[[[x, x, x, x, x], [x, x, x, x, x]],
-    // [[x, x, x, x, x], [x, x, x, x, x]],
-    // [[x, x, x, x, x], [x, x, x, x, x]]]
-
-    if (m_shape.getNumDims() == 0) {
-        throw std::runtime_error("Can not index tensor of zero dimensions");
-        return std::unique_ptr<Tensor::Impl>(new Tensor::CPUImpl(*this));
-    }
-
-    if (m_shape.getNumDims() == 1 && m_shape.getDim(0) == 1) {
-        throw std::runtime_error("Can not index tensor of one dimension and one element");
-        return std::unique_ptr<Tensor::Impl>(new Tensor::CPUImpl(*this));
-    }
-
-    Tensor::Shape newShape = m_shape.getSlice(1, m_shape.getNumDims());
-    Tensor::CPUImpl* results = new Tensor::CPUImpl(newShape);
-
-    size_t offset = newShape.getNumElements() * idx;
-    for (size_t i = 0; i < newShape.getNumElements(); i++) {
-        results->m_data[i] = m_data[i + offset];
-    }
-
-    return std::unique_ptr<Tensor::Impl>(results);
-}
-
 void Tensor::CPUImpl::set(size_t lhsOffset, const Tensor::Impl* rhs, size_t rhsOffset, size_t count) {
     const Tensor::CPUImpl* o = static_cast<const Tensor::CPUImpl*>(rhs);
 

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -61,6 +61,10 @@ std::string Tensor::backendString() const {
 	}
 }
 
+Backend Tensor::getBackend() const {
+	return m_backend;
+}
+
 std::string Tensor::dataString() const {
 	return m_impl->toString();
 }

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -1,237 +1,232 @@
 #include "nforge/core/tensor.h"
-#include "nforge/core/tensor_view.h"
-#include "nforge/backend/cpu/tensor_impl_CPU.h"
 
+#include "nforge/backend/cpu/tensor_impl_CPU.h"
+#include "nforge/core/tensor_view.h"
 #include "ops/semantic/semantic.h"
 
-Tensor::Tensor(const Tensor::Shape& shape, Backend backend) 
-	: m_backend(backend) {
-	if (backend == Backend::CPU) {
-		m_impl = std::make_unique<Tensor::CPUImpl>(shape);
-	}
-	else {
-		// TODO: should assert to false, but it's necessary to 
-		// have a valid non-cpu tensor in testing
-		std::cout << "backend not implemented! defaulting to cpu\n";
-		m_impl = std::make_unique<Tensor::CPUImpl>(shape);
-	}
+Tensor::Tensor(const Tensor::Shape& shape, Backend backend)
+    : m_backend(backend) {
+    if (backend == Backend::CPU) {
+        m_impl = std::make_unique<Tensor::CPUImpl>(shape);
+    } else {
+        // TODO: should assert to false, but it's necessary to
+        // have a valid non-cpu tensor in testing
+        std::cout << "backend not implemented! defaulting to cpu\n";
+        m_impl = std::make_unique<Tensor::CPUImpl>(shape);
+    }
 }
 
-Tensor::Tensor(const Tensor::Shape& shape, float value, Backend backend) 
-	: Tensor(shape, backend) {
-	m_impl->fillAll(value);
+Tensor::Tensor(const Tensor::Shape& shape, float value, Backend backend)
+    : Tensor(shape, backend) {
+    m_impl->fillAll(value);
 }
 
-Tensor::Tensor(float value, Backend backend) 
-	: Tensor(Tensor::Shape({1}), value, backend) {
+Tensor::Tensor(float value, Backend backend)
+    : Tensor(Tensor::Shape({1}), value, backend) {
 }
 
-Tensor::Tensor(const Tensor& other) 
-	: m_backend(other.m_backend), m_impl(other.m_impl->clone()) {
+Tensor::Tensor(const Tensor& other)
+    : m_backend(other.m_backend), m_impl(other.m_impl->clone()) {
 }
 
 Tensor::Tensor(std::unique_ptr<Tensor::Impl> impl, Backend backend)
-	: m_impl(std::move(impl)), m_backend(backend) {
+    : m_impl(std::move(impl)), m_backend(backend) {
 }
 
 Tensor::~Tensor() {
 }
 
 void Tensor::fillAll(float value) {
-	m_impl->fillAll(value);
+    m_impl->fillAll(value);
 }
 
 void Tensor::fillRand() {
-	m_impl->fillRand();
+    m_impl->fillRand();
 }
 
 void Tensor::print() const {
-	m_impl->print();
+    m_impl->print();
 }
 
 void Tensor::print(const std::vector<size_t>& idx) const {
-	m_impl->print(idx);
+    m_impl->print(idx);
 }
 
-Tensor::Shape Tensor::shape() const {
-	return m_impl->shape();
+Tensor::Shape Tensor::getShape() const {
+    return m_impl->shape();
 }
 
-std::string Tensor::backendString() const {
-	switch (m_backend) {
-		case Backend::CPU:
-			return "CPU";
-		case Backend::CUDA:
-			return "CUDA";
-		default:
-			return "UNKNOWN";
-	}
+std::string Tensor::getBackendString() const {
+    switch (m_backend) {
+        case Backend::CPU:
+            return "CPU";
+        case Backend::CUDA:
+            return "CUDA";
+        default:
+            return "UNKNOWN";
+    }
 }
 
 Backend Tensor::getBackend() const {
-	return m_backend;
+    return m_backend;
 }
 
-std::string Tensor::dataString() const {
-	return m_impl->toString();
+std::string Tensor::getDataString() const {
+    return m_impl->toString();
 }
 
-size_t Tensor::numElements() const {
-	return m_impl->numElements();
+size_t Tensor::getNumElements() const {
+    return m_impl->numElements();
 }
 
 std::vector<float> Tensor::toVector() const {
-	return m_impl->toVector();
+    return m_impl->toVector();
 }
 
 void Tensor::set(const std::vector<size_t>& position, const Tensor& rhs) {
-	Tensor::View lhs = Tensor::View((Tensor&)*this, position);
+    Tensor::View lhs = Tensor::View((Tensor&)*this, position);
 
-	auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
+    auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
 
-	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
-        throw std::runtime_error("Can't set position on tensors with shape mismatch, "
-            + lhs.getShape().toString() + " and " + rhs.shape().toString());
-	}
+    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+        throw std::runtime_error("Can't set position on tensors with shape mismatch, " + lhs.getShape().toString() + " and " + rhs.getShape().toString());
+    }
 
-	m_impl->set(
-		ctx.lhsOffset,
-		*rhs.m_impl,
-		ctx.rhsOffset,
-		ctx.count
-	);
+    m_impl->set(
+        ctx.lhsOffset,
+        *rhs.m_impl,
+        ctx.rhsOffset,
+        ctx.count);
 }
 
 void Tensor::set(const std::vector<size_t>& position, const Tensor::View& rhs) {
-	Tensor::View lhs = Tensor::View((Tensor&)*this, position);
+    Tensor::View lhs = Tensor::View((Tensor&)*this, position);
 
-	auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
+    auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
 
-	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
-        throw std::runtime_error("Can't set position on tensors with shape mismatch, "
-            + lhs.getShape().toString() + " and " + rhs.getShape().toString());
-	}
+    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+        throw std::runtime_error("Can't set position on tensors with shape mismatch, " + lhs.getShape().toString() + " and " + rhs.getShape().toString());
+    }
 
-	m_impl->set(
-		ctx.lhsOffset,
-		*rhs.getParent().m_impl,
-		ctx.rhsOffset,
-		ctx.count
-	);
+    m_impl->set(
+        ctx.lhsOffset,
+        *rhs.getParent().m_impl,
+        ctx.rhsOffset,
+        ctx.count);
 }
 
 bool Tensor::compare(const Tensor& rhs) const {
-	auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
+    auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
 
-	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
-		return false;
-	}
+    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+        return false;
+    }
 
-	return m_impl->compare(
-		ctx.lhsOffset,
-		*rhs.m_impl,
-		ctx.rhsOffset,
-		ctx.count
-	);
+    return m_impl->compare(
+        ctx.lhsOffset,
+        *rhs.m_impl,
+        ctx.rhsOffset,
+        ctx.count);
 }
 
 bool Tensor::compare(const Tensor::View& rhs) const {
-	auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
+    auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
 
-	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
-		return false;
-	}
+    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+        return false;
+    }
 
-	return m_impl->compare(
-		ctx.lhsOffset,
-		*rhs.getParent().m_impl,
-		ctx.rhsOffset,
-		ctx.count
-	);
+    return m_impl->compare(
+        ctx.lhsOffset,
+        *rhs.getParent().m_impl,
+        ctx.rhsOffset,
+        ctx.count);
 }
 
 bool Tensor::compare(const std::vector<size_t>& position, const Tensor& rhs) const {
-	Tensor::View lhs = Tensor::View((Tensor&)*this, position);
-	
-	auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
+    Tensor::View lhs = Tensor::View((Tensor&)*this, position);
 
-	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
-		return false;
-	}
+    auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
 
-	return m_impl->compare(
-		ctx.lhsOffset,
-		*rhs.m_impl,
-		ctx.rhsOffset,
-		ctx.count
-	);
+    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+        return false;
+    }
+
+    return m_impl->compare(
+        ctx.lhsOffset,
+        *rhs.m_impl,
+        ctx.rhsOffset,
+        ctx.count);
 }
 
 bool Tensor::compare(const std::vector<size_t>& position, const Tensor::View& rhs) const {
-	Tensor::View lhs = Tensor::View((Tensor&)*this, position);
+    Tensor::View lhs = Tensor::View((Tensor&)*this, position);
 
-	auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
-	
-	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
-		return false;
-	}
+    auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
 
-	return m_impl->compare(
-		ctx.lhsOffset,
-		*rhs.getParent().m_impl,
-		ctx.rhsOffset,
-		ctx.count
-	);
+    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+        return false;
+    }
+
+    return m_impl->compare(
+        ctx.lhsOffset,
+        *rhs.getParent().m_impl,
+        ctx.rhsOffset,
+        ctx.count);
 }
 
 Tensor Tensor::operator+(const Tensor& other) const {
-	if (other.shape().isScalar()) {
-		return Tensor(m_impl->addScalar(*other.m_impl), m_backend);
-	}
-	return Tensor(m_impl->add(*other.m_impl), m_backend);
+    if (other.getShape().isScalar()) {
+        return Tensor(m_impl->addScalar(*other.m_impl), m_backend);
+    }
+    return Tensor(m_impl->add(*other.m_impl), m_backend);
 }
 
 Tensor Tensor::operator-(const Tensor& other) const {
-	if (other.shape().isScalar()) {
-		return Tensor(m_impl->subScalar(*other.m_impl), m_backend);
-	}
-	return Tensor(m_impl->sub(*other.m_impl), m_backend);
+    if (other.getShape().isScalar()) {
+        return Tensor(m_impl->subScalar(*other.m_impl), m_backend);
+    }
+    return Tensor(m_impl->sub(*other.m_impl), m_backend);
 }
 
 Tensor Tensor::operator*(const Tensor& other) const {
-	if (other.shape().isScalar()) {
-		return Tensor(m_impl->mulScalar(*other.m_impl), m_backend);
-	}
-	return Tensor(m_impl->mul(*other.m_impl), m_backend);
+    if (other.getShape().isScalar()) {
+        return Tensor(m_impl->mulScalar(*other.m_impl), m_backend);
+    }
+    return Tensor(m_impl->mul(*other.m_impl), m_backend);
 }
 
 Tensor Tensor::operator/(const Tensor& other) const {
-	if (other.shape().isScalar()) {
-		return Tensor(m_impl->divScalar(*other.m_impl), m_backend);
-	}
-	return Tensor(m_impl->div(*other.m_impl), m_backend);
+    if (other.getShape().isScalar()) {
+        return Tensor(m_impl->divScalar(*other.m_impl), m_backend);
+    }
+    return Tensor(m_impl->div(*other.m_impl), m_backend);
 }
 
 Tensor::View Tensor::operator[](size_t idx) const {
-	Tensor::View results((Tensor&)*this, {idx});
-	return results;
+    Tensor::View results((Tensor&)*this, {idx});
+    return results;
 }
 
 Tensor Tensor::operator=(const Tensor& other) {
-	this->m_impl = other.m_impl->clone();
-	this->m_backend = other.m_backend;
-	
-	return *this;
+    this->m_impl = other.m_impl->clone();
+    this->m_backend = other.m_backend;
+
+    return *this;
 }
 
 bool Tensor::operator==(const Tensor& rhs) const {
-	return compare(rhs);
+    return compare(rhs);
 }
 
 bool Tensor::operator==(const Tensor::View& rhs) const {
-	return compare(rhs);
+    return compare(rhs);
 }
 
 bool Tensor::operator!=(const Tensor& other) const {
-	return !operator==(other);
+    return !operator==(other);
+}
+
+bool Tensor::operator!=(const Tensor::View& other) const {
+    return !operator==(other);
 }

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -86,9 +86,9 @@ std::vector<float> Tensor::toVector() const {
 void Tensor::set(const std::vector<size_t>& position, const Tensor& rhs) {
     Tensor::View lhs = Tensor::View((Tensor&)*this, position);
 
-    auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
+    auto ctx = semantic::validateBinaryOperation(lhs, rhs);
 
-    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+    if (ctx.shapeMatch != semantic::ShapeMatch::Equal) {
         throw std::runtime_error("Can't set position on tensors with shape mismatch, " + lhs.getShape().toString() + " and " + rhs.getShape().toString());
     }
 
@@ -102,9 +102,9 @@ void Tensor::set(const std::vector<size_t>& position, const Tensor& rhs) {
 void Tensor::set(const std::vector<size_t>& position, const Tensor::View& rhs) {
     Tensor::View lhs = Tensor::View((Tensor&)*this, position);
 
-    auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
+    auto ctx = semantic::validateBinaryOperation(lhs, rhs);
 
-    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+    if (ctx.shapeMatch != semantic::ShapeMatch::Equal) {
         throw std::runtime_error("Can't set position on tensors with shape mismatch, " + lhs.getShape().toString() + " and " + rhs.getShape().toString());
     }
 
@@ -116,9 +116,9 @@ void Tensor::set(const std::vector<size_t>& position, const Tensor::View& rhs) {
 }
 
 bool Tensor::compare(const Tensor& rhs) const {
-    auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
+    auto ctx = semantic::validateBinaryOperation(*this, rhs);
 
-    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+    if (ctx.shapeMatch != semantic::ShapeMatch::Equal) {
         return false;
     }
 
@@ -130,9 +130,9 @@ bool Tensor::compare(const Tensor& rhs) const {
 }
 
 bool Tensor::compare(const Tensor::View& rhs) const {
-    auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
+    auto ctx = semantic::validateBinaryOperation(*this, rhs);
 
-    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+    if (ctx.shapeMatch != semantic::ShapeMatch::Equal) {
         return false;
     }
 
@@ -146,9 +146,9 @@ bool Tensor::compare(const Tensor::View& rhs) const {
 bool Tensor::compare(const std::vector<size_t>& position, const Tensor& rhs) const {
     Tensor::View lhs = Tensor::View((Tensor&)*this, position);
 
-    auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
+    auto ctx = semantic::validateBinaryOperation(lhs, rhs);
 
-    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+    if (ctx.shapeMatch != semantic::ShapeMatch::Equal) {
         return false;
     }
 
@@ -162,9 +162,9 @@ bool Tensor::compare(const std::vector<size_t>& position, const Tensor& rhs) con
 bool Tensor::compare(const std::vector<size_t>& position, const Tensor::View& rhs) const {
     Tensor::View lhs = Tensor::View((Tensor&)*this, position);
 
-    auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
+    auto ctx = semantic::validateBinaryOperation(lhs, rhs);
 
-    if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+    if (ctx.shapeMatch != semantic::ShapeMatch::Equal) {
         return false;
     }
 
@@ -176,19 +176,19 @@ bool Tensor::compare(const std::vector<size_t>& position, const Tensor::View& rh
 }
 
 Tensor Tensor::operator+(const Tensor& rhs) const {
-	auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
+	auto ctx = semantic::validateBinaryOperation(*this, rhs);
 
 	std::unique_ptr<Tensor::Impl> results;
 	switch (ctx.shapeMatch) {
-		case nforge::semantic::ShapeMatch::Equal:
+		case semantic::ShapeMatch::Equal:
 			results = m_impl->add(ctx.lhsOffset, *rhs.m_impl, ctx.rhsOffset, ctx.count);
 			break;
 
-		case nforge::semantic::ShapeMatch::ScalarLhs:
+		case semantic::ShapeMatch::ScalarLhs:
 			results = rhs.m_impl->addScalar(ctx.rhsOffset, *m_impl, ctx.count);
 			break;
 		
-		case nforge::semantic::ShapeMatch::ScalarRhs:
+		case semantic::ShapeMatch::ScalarRhs:
 			results = m_impl->addScalar(ctx.lhsOffset, *rhs.m_impl, ctx.count);
 			break;
 		
@@ -201,19 +201,19 @@ Tensor Tensor::operator+(const Tensor& rhs) const {
 }
 
 Tensor Tensor::operator-(const Tensor& rhs) const {
-	auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
+	auto ctx = semantic::validateBinaryOperation(*this, rhs);
 
 	std::unique_ptr<Tensor::Impl> results;
 	switch (ctx.shapeMatch) {
-		case nforge::semantic::ShapeMatch::Equal:
+		case semantic::ShapeMatch::Equal:
 			results = m_impl->sub(ctx.lhsOffset, *rhs.m_impl, ctx.rhsOffset, ctx.count);
 			break;		
 
-		case nforge::semantic::ShapeMatch::ScalarLhs:
+		case semantic::ShapeMatch::ScalarLhs:
 			results = rhs.m_impl->subScalar(ctx.rhsOffset, *m_impl, ctx.count);
 			break;		
 		
-		case nforge::semantic::ShapeMatch::ScalarRhs:
+		case semantic::ShapeMatch::ScalarRhs:
 			results = m_impl->subScalar(ctx.lhsOffset, *rhs.m_impl, ctx.count);
 			break;		
 		
@@ -226,19 +226,19 @@ Tensor Tensor::operator-(const Tensor& rhs) const {
 }
 
 Tensor Tensor::operator*(const Tensor& rhs) const {
-	auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
+	auto ctx = semantic::validateBinaryOperation(*this, rhs);
 
 	std::unique_ptr<Tensor::Impl> results;
 	switch (ctx.shapeMatch) {
-		case nforge::semantic::ShapeMatch::Equal:
+		case semantic::ShapeMatch::Equal:
 			results = m_impl->mul(ctx.lhsOffset, *rhs.m_impl, ctx.rhsOffset, ctx.count);
 			break;		
 
-		case nforge::semantic::ShapeMatch::ScalarLhs:
+		case semantic::ShapeMatch::ScalarLhs:
 			results = rhs.m_impl->mulScalar(ctx.rhsOffset, *m_impl, ctx.count);
 			break;		
 		
-		case nforge::semantic::ShapeMatch::ScalarRhs:
+		case semantic::ShapeMatch::ScalarRhs:
 			results = m_impl->mulScalar(ctx.lhsOffset, *rhs.m_impl, ctx.count);
 			break;		
 		
@@ -251,19 +251,19 @@ Tensor Tensor::operator*(const Tensor& rhs) const {
 }
 
 Tensor Tensor::operator/(const Tensor& rhs) const {
-	auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
+	auto ctx = semantic::validateBinaryOperation(*this, rhs);
 
 	std::unique_ptr<Tensor::Impl> results;
 	switch (ctx.shapeMatch) {
-		case nforge::semantic::ShapeMatch::Equal:
+		case semantic::ShapeMatch::Equal:
 			results = m_impl->div(ctx.lhsOffset, *rhs.m_impl, ctx.rhsOffset, ctx.count);
 			break;		
 
-		case nforge::semantic::ShapeMatch::ScalarLhs:
+		case semantic::ShapeMatch::ScalarLhs:
 			results = rhs.m_impl->divScalar(ctx.rhsOffset, *m_impl, ctx.count);
 			break;		
 		
-		case nforge::semantic::ShapeMatch::ScalarRhs:
+		case semantic::ShapeMatch::ScalarRhs:
 			results = m_impl->divScalar(ctx.lhsOffset, *rhs.m_impl, ctx.count);
 			break;		
 

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -89,6 +89,11 @@ void Tensor::set(const std::vector<size_t>& position, const Tensor& rhs) {
 
 	auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
 
+	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+        throw std::runtime_error("Can't set position on tensors with shape mismatch, "
+            + lhs.getShape().toString() + " and " + rhs.shape().toString());
+	}
+
 	m_impl->set(
 		ctx.lhsOffset,
 		*rhs.m_impl,
@@ -102,6 +107,11 @@ void Tensor::set(const std::vector<size_t>& position, const Tensor::View& rhs) {
 
 	auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
 
+	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+        throw std::runtime_error("Can't set position on tensors with shape mismatch, "
+            + lhs.getShape().toString() + " and " + rhs.getShape().toString());
+	}
+
 	m_impl->set(
 		ctx.lhsOffset,
 		*rhs.getParent().m_impl,
@@ -113,6 +123,10 @@ void Tensor::set(const std::vector<size_t>& position, const Tensor::View& rhs) {
 bool Tensor::compare(const Tensor& rhs) const {
 	auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
 
+	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+		return false;
+	}
+
 	return m_impl->compare(
 		ctx.lhsOffset,
 		*rhs.m_impl,
@@ -123,6 +137,10 @@ bool Tensor::compare(const Tensor& rhs) const {
 
 bool Tensor::compare(const Tensor::View& rhs) const {
 	auto ctx = nforge::semantic::validateBinaryOperation(*this, rhs);
+
+	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+		return false;
+	}
 
 	return m_impl->compare(
 		ctx.lhsOffset,
@@ -137,6 +155,10 @@ bool Tensor::compare(const std::vector<size_t>& position, const Tensor& rhs) con
 	
 	auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
 
+	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+		return false;
+	}
+
 	return m_impl->compare(
 		ctx.lhsOffset,
 		*rhs.m_impl,
@@ -150,6 +172,10 @@ bool Tensor::compare(const std::vector<size_t>& position, const Tensor::View& rh
 
 	auto ctx = nforge::semantic::validateBinaryOperation(lhs, rhs);
 	
+	if (ctx.shapeMatch != nforge::semantic::ShapeMatch::Equal) {
+		return false;
+	}
+
 	return m_impl->compare(
 		ctx.lhsOffset,
 		*rhs.getParent().m_impl,

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -8,7 +8,10 @@ Tensor::Tensor(const Tensor::Shape& shape, Backend backend)
 		m_impl = std::make_unique<Tensor::CPUImpl>(shape);
 	}
 	else {
-		assert(false);
+		// TODO: should assert to false, but it's necessary to 
+		// have a valid non-cpu tensor in testing
+		std::cout << "backend not implemented! defaulting to cpu\n";
+		m_impl = std::make_unique<Tensor::CPUImpl>(shape);
 	}
 }
 
@@ -56,6 +59,8 @@ std::string Tensor::backendString() const {
 	switch (m_backend) {
 		case Backend::CPU:
 			return "CPU";
+		case Backend::CUDA:
+			return "CUDA";
 		default:
 			return "UNKNOWN";
 	}

--- a/src/core/tensor_shape.cpp
+++ b/src/core/tensor_shape.cpp
@@ -62,7 +62,7 @@ size_t Tensor::Shape::getDim(size_t idx) const {
 }
 
 bool Tensor::Shape::isScalar() const {
-    return getNumElements() == 1;
+    return m_dimensions.size() == 1 && m_dimensions[0] == 1;
 }
 
 Tensor::Shape Tensor::Shape::removeLeadingDimension() const {

--- a/src/core/tensor_shape.cpp
+++ b/src/core/tensor_shape.cpp
@@ -1,34 +1,34 @@
 #include "nforge/core/tensor_shape.h"
 
-#include <numeric>
 #include <algorithm>
+#include <numeric>
 #include <stdexcept>
 
 Tensor::Shape::Shape(const std::vector<size_t>& dims) : m_dimensions(dims) {
     if (dims.empty()) {
-        m_dimensions.push_back(1); // scalar tensors have shape {1}
+        m_dimensions.push_back(1);  // scalar tensors have shape {1}
     }
 }
 
 Tensor::Shape::Shape(const std::initializer_list<size_t>& dims) : m_dimensions(dims) {
     if (dims.size() == 0) {
-        m_dimensions.push_back(1); // scalar tensors have shape {1}
+        m_dimensions.push_back(1);  // scalar tensors have shape {1}
     }
 }
 
-bool Tensor::Shape::operator==(const Shape &other) const {
+bool Tensor::Shape::operator==(const Shape& other) const {
     return this->withoutTrailingOnes() == other.withoutTrailingOnes();
 }
 
-bool Tensor::Shape::operator!=(const Shape &other) const {
+bool Tensor::Shape::operator!=(const Shape& other) const {
     return !(this->operator==(other));
 }
 
-size_t Tensor::Shape::getNumDims() const { 
+size_t Tensor::Shape::getNumDims() const {
     return m_dimensions.size();
 }
 
-Tensor::Shape Tensor::Shape::operator[](size_t index) const { 
+Tensor::Shape Tensor::Shape::operator[](size_t index) const {
     if (m_dimensions.size() == 1) {
         return Tensor::Shape({1});
     }
@@ -37,7 +37,7 @@ Tensor::Shape Tensor::Shape::operator[](size_t index) const {
     return Tensor::Shape(dims);
 }
 
-Tensor::Shape Tensor::Shape::operator[](const std::vector<size_t>& position) const { 
+Tensor::Shape Tensor::Shape::operator[](const std::vector<size_t>& position) const {
     size_t numIndexedDims = position.size();
     size_t remainDims = m_dimensions.size() - numIndexedDims;
     if (remainDims <= 0) {
@@ -99,7 +99,7 @@ std::vector<size_t> Tensor::Shape::withoutTrailingOnes() const {
     }
     // maintain at least one dimension
     if (result.empty()) {
-        result.push_back(1); 
+        result.push_back(1);
     }
     return result;
 }

--- a/src/core/tensor_shape.cpp
+++ b/src/core/tensor_shape.cpp
@@ -24,15 +24,31 @@ bool Tensor::Shape::operator!=(const Shape &other) const {
     return !(this->operator==(other));
 }
 
-size_t Tensor::Shape::dims() const { 
+size_t Tensor::Shape::getNumDims() const { 
     return m_dimensions.size();
 }
 
-size_t Tensor::Shape::operator[](size_t index) const { 
-    return m_dimensions[index]; 
+Tensor::Shape Tensor::Shape::operator[](size_t index) const { 
+    if (m_dimensions.size() == 1) {
+        return Tensor::Shape({1});
+    }
+
+    std::vector<size_t> dims(m_dimensions.begin() + 1, m_dimensions.end());
+    return Tensor::Shape(dims);
 }
 
-size_t Tensor::Shape::totalSize() const {
+Tensor::Shape Tensor::Shape::operator[](const std::vector<size_t>& position) const { 
+    size_t numIndexedDims = position.size();
+    size_t remainDims = m_dimensions.size() - numIndexedDims;
+    if (remainDims <= 0) {
+        return Tensor::Shape({1});
+    }
+
+    std::vector<size_t> dims(m_dimensions.begin() + numIndexedDims, m_dimensions.end());
+    return Tensor::Shape(dims);
+}
+
+size_t Tensor::Shape::getNumElements() const {
     if (m_dimensions.empty()) {
         return 0;
     }
@@ -41,8 +57,12 @@ size_t Tensor::Shape::totalSize() const {
                            size_t(1), std::multiplies<size_t>());
 }
 
+size_t Tensor::Shape::getDim(size_t idx) const {
+    return m_dimensions[idx];
+}
+
 bool Tensor::Shape::isScalar() const {
-    return totalSize() == 1;
+    return getNumElements() == 1;
 }
 
 Tensor::Shape Tensor::Shape::removeLeadingDimension() const {
@@ -52,7 +72,7 @@ Tensor::Shape Tensor::Shape::removeLeadingDimension() const {
     return Shape(std::vector<size_t>(m_dimensions.begin() + 1, m_dimensions.end()));
 }
 
-Tensor::Shape Tensor::Shape::slice(size_t start, size_t end) const {
+Tensor::Shape Tensor::Shape::getSlice(size_t start, size_t end) const {
     if (start > end || end > m_dimensions.size()) {
         throw std::out_of_range("Invalid slice range");
     }

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -5,6 +5,9 @@ Tensor::View::View(Tensor& parent, const std::vector<size_t>& index)
 }
 
 void Tensor::View::print() const {
+    std::cout << "View at position: ";
+    for (auto e : m_position) std::cout << e << " ";
+    std::cout << "\n";
     m_parent.print(m_position);
 }
 

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -1,10 +1,10 @@
 #include "nforge/core/tensor_view.h"
 
-Tensor::View::View(Tensor& parent, const std::vector<size_t>& index) 
+Tensor::View::View(Tensor& parent, const std::vector<size_t>& index)
     : m_parent(parent), m_position(index) {
 }
 
-Tensor::View::View(const Tensor& parent) 
+Tensor::View::View(const Tensor& parent)
     : m_parent((Tensor&)parent), m_position({}) {
 }
 
@@ -27,11 +27,11 @@ size_t Tensor::View::getOffset() const {
     if (m_position.empty()) {
         return 0;
     }
-    
+
     Tensor::Shape blockShape = getShape();
     size_t blockSize = blockShape.getNumElements();
 
-    size_t blockOffset = 1;    
+    size_t blockOffset = 1;
     for (size_t d : m_position) {
         blockOffset *= d;
     }
@@ -40,7 +40,7 @@ size_t Tensor::View::getOffset() const {
 }
 
 Tensor::Shape Tensor::View::getShape() const {
-    return m_parent.shape()[m_position];
+    return m_parent.getShape()[m_position];
 }
 
 Tensor Tensor::View::operator=(const Tensor& other) {

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -4,6 +4,10 @@ Tensor::View::View(Tensor& parent, const std::vector<size_t>& index)
     : m_parent(parent), m_position(index) {
 }
 
+Tensor::View::View(const Tensor& parent) 
+    : m_parent((Tensor&)parent), m_position({}) {
+}
+
 void Tensor::View::print() const {
     std::cout << "View at position: ";
     for (auto e : m_position) std::cout << e << " ";
@@ -20,10 +24,14 @@ std::vector<size_t> Tensor::View::getPosition() const {
 }
 
 size_t Tensor::View::getOffset() const {
+    if (m_position.empty()) {
+        return 0;
+    }
+    
     Tensor::Shape blockShape = getShape();
     size_t blockSize = blockShape.getNumElements();
 
-    size_t blockOffset = 1;
+    size_t blockOffset = 1;    
     for (size_t d : m_position) {
         blockOffset *= d;
     }

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -33,10 +33,10 @@ size_t Tensor::View::getOffset() const {
 
     size_t blockOffset = 1;
     for (size_t d : m_position) {
-        blockOffset *= d;
+        blockOffset *= (d + 1);
     }
 
-    return blockOffset * blockSize;
+    return (blockOffset - 1) * blockSize;
 }
 
 Tensor::Shape Tensor::View::getShape() const {

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -8,12 +8,28 @@ void Tensor::View::print() const {
     m_parent.print(m_position);
 }
 
+Tensor& Tensor::View::getParent() const {
+    return m_parent;
+}
+
 std::vector<size_t> Tensor::View::getPosition() const {
     return m_position;
 }
 
-Tensor& Tensor::View::getParent() const {
-    return m_parent;
+size_t Tensor::View::getOffset() const {
+    Tensor::Shape blockShape = getShape();
+    size_t blockSize = blockShape.getNumElements();
+
+    size_t blockOffset = 1;
+    for (size_t d : m_position) {
+        blockOffset *= d;
+    }
+
+    return blockOffset * blockSize;
+}
+
+Tensor::Shape Tensor::View::getShape() const {
+    return m_parent.shape()[m_position];
 }
 
 Tensor Tensor::View::operator=(const Tensor& other) {

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -1,26 +1,22 @@
 #include "ops/semantic/semantic.h"
 
-
 namespace nforge::semantic {
 
 void ensureSameBackend(const Tensor& lhs, const Tensor& rhs) {
     if (lhs.getBackend() != rhs.getBackend()) {
-        throw std::runtime_error("Can not perform binary operation on tensor on different devices " 
-            + lhs.backendString() + " and " + rhs.backendString() + " of shapes " 
-            + lhs.shape().toString() + " and " + rhs.shape().toString());
+        throw std::runtime_error("Can not perform binary operation on tensor on different devices " + lhs.backendString() + " and " + rhs.backendString() + " of shapes " + lhs.getShape().toString() + " and " + rhs.getShape().toString());
     }
 }
 
 void ensureSameShape(Tensor::Shape lhsShape, Tensor::Shape rhsShape) {
     if (lhsShape != rhsShape) {
-        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, "
-            + lhsShape.toString() + " and " + rhsShape.toString());
+        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, " + lhsShape.toString() + " and " + rhsShape.toString());
     }
 }
 
 ShapeMatch getShapeRelation(const Tensor::Shape& lhs, const Tensor::Shape& rhs) {
     // keep order, must match order of ShapeMatch
-    if (lhs == rhs) { 
+    if (lhs == rhs) {
         return ShapeMatch::Equal;
     }
 
@@ -42,7 +38,7 @@ ShapeMatch getShapeRelation(const Tensor::Shape& lhs, const Tensor::Shape& rhs) 
 size_t getOperationCount(const Tensor::Shape& lhs, const Tensor::Shape& rhs, ShapeMatch shapeMatch) {
     size_t cntLhs = lhs.getNumElements();
     size_t cntRhs = rhs.getNumElements();
-    
+
     switch (shapeMatch) {
         case ShapeMatch::Equal:
             return cntLhs;
@@ -90,5 +86,4 @@ BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::V
     return buildContext(lhs, rhs);
 }
 
-
-} // nforge::semantic
+}  // namespace nforge::semantic

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -3,101 +3,39 @@
 
 namespace nforge::semantic {
 
-
-BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor& rhs) {
-    // must have equal backend
+void ensureSameBackend(const Tensor& lhs, const Tensor& rhs) {
     if (lhs.getBackend() != rhs.getBackend()) {
         throw std::runtime_error("Can not perform binary operation on tensor on different devices " 
             + lhs.backendString() + " and " + rhs.backendString() + " of shapes " 
             + lhs.shape().toString() + " and " + rhs.shape().toString());
     }
+}
 
-    // must have equal shapes
-    if (lhs.shape() != rhs.shape()) {
+void ensureSameShape(Tensor::Shape lhsShape, Tensor::Shape rhsShape) {
+    if (lhsShape != rhsShape) {
         throw std::runtime_error("Can not perform binary operations on tensors of different shapes, "
-            + lhs.shape().toString() + " and " + rhs.shape().toString());
+            + lhsShape.toString() + " and " + rhsShape.toString());
     }
+}
 
-    Tensor::Shape shape = rhs.shape();
-    
-    BinaryOpContext ctx;
-    ctx.lhsOffset = 0;
-    ctx.rhsOffset = 0;
-    ctx.count = shape.getNumElements();
-
-    return ctx;
+BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor& rhs) {
+    return validateBinaryOperation(Tensor::View(lhs), Tensor::View(rhs));
 }
 
 BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor::View& rhs) {
-    const Tensor& rhsParent = rhs.getParent();
-    
-    // must have equal backend
-    if (lhs.getBackend() != rhsParent.getBackend()) {
-        throw std::runtime_error("Can not perform binary operation on tensor views on different devices " 
-            + lhs.backendString() + " and " + lhs.backendString() + " of shapes " 
-            + lhs.shape().toString() + " and " + rhs.getShape().toString());
-    }
-
-
-    // must have equal shapes
-    if (lhs.shape() != rhs.getShape()) {
-        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, "
-            + lhs.shape().toString() + " and " + rhs.getShape().toString());
-    }
-
-    Tensor::Shape shape = rhs.getShape();
-
-    BinaryOpContext ctx;
-    ctx.lhsOffset = 0;
-    ctx.rhsOffset = rhs.getOffset();
-    ctx.count = shape.getNumElements();
-
-    return ctx;
+    return validateBinaryOperation(Tensor::View(lhs), rhs);
 }
 
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor& rhs) {
-    const Tensor& lhsParent = lhs.getParent();
-
-    // must have equal backend
-    if (lhsParent.getBackend() != rhs.getBackend()) {
-        throw std::runtime_error("Can not perform binary operation on tensor views on different devices " 
-            + lhsParent.backendString() + " and " + rhs.backendString() + " of shapes " 
-            + lhs.getShape().toString() + " and " + rhs.shape().toString());
-    }
-
-    // must have equal shapes
-    if (lhs.getShape() != rhs.shape()) {
-        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, "
-            + lhs.getShape().toString() + " and " + rhs.shape().toString());
-    }
-
-    Tensor::Shape shape = rhs.shape();
-
-    BinaryOpContext ctx;
-    ctx.lhsOffset = lhs.getOffset();
-    ctx.rhsOffset = 0;
-    ctx.count = shape.getNumElements();
-
-    return ctx;
+    return validateBinaryOperation(lhs, Tensor::View(rhs));
 }
 
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs) {
     const Tensor& lhsParent = lhs.getParent();
     const Tensor& rhsParent = rhs.getParent();
     
-    // must have equal backend
-    if (lhsParent.getBackend() != rhsParent.getBackend()) {
-        throw std::runtime_error("Can not perform binary operation on tensor views on different devices " 
-            + lhsParent.backendString() + " and " + rhsParent.backendString() + " of shapes " 
-            + lhs.getShape().toString() + " and " + rhs.getShape().toString());
-    }
-
-
-    // must have equal shapes
-    if (lhs.getShape() != rhs.getShape()) {
-        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, "
-            + lhs.getShape().toString() + " and " + rhs.getShape().toString());
-    }
+    ensureSameBackend(lhsParent, rhsParent);
+    ensureSameShape(lhs.getShape(), rhs.getShape());
 
     Tensor::Shape shape = rhs.getShape();
 
@@ -108,6 +46,5 @@ BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::V
 
     return ctx;
 }
-
 
 } // nforge::semantic

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -1,19 +1,12 @@
 #include "ops/semantic/semantic.h"
 
-namespace nforge::semantic {
+namespace semantic {
 
 void ensureSameBackend(const Tensor& lhs, const Tensor& rhs) {
     if (lhs.getBackend() != rhs.getBackend()) {
         throw std::runtime_error("Can not perform binary operation on tensor on different devices " 
             + lhs.getBackendString() + " and " + rhs.getBackendString() + " of shapes " 
             + lhs.getShape().toString() + " and " + rhs.getShape().toString());
-    }
-}
-
-void ensureSameShape(Tensor::Shape lhsShape, Tensor::Shape rhsShape) {
-    if (lhsShape != rhsShape) {
-        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, " 
-            + lhsShape.toString() + " and " + rhsShape.toString());
     }
 }
 
@@ -89,4 +82,4 @@ BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::V
     return buildContext(lhs, rhs);
 }
 
-}  // namespace nforge::semantic
+}  // namespace semantic

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -28,6 +28,58 @@ BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor& rhs) {
     return ctx;
 }
 
+BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor::View& rhs) {
+    const Tensor& rhsParent = rhs.getParent();
+    
+    // must have equal backend
+    if (lhs.getBackend() != rhsParent.getBackend()) {
+        throw std::runtime_error("Can not perform binary operation on tensor views on different devices " 
+            + lhs.backendString() + " and " + lhs.backendString() + " of shapes " 
+            + lhs.shape().toString() + " and " + rhs.getShape().toString());
+    }
+
+
+    // must have equal shapes
+    if (lhs.shape() != rhs.getShape()) {
+        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, "
+            + lhs.shape().toString() + " and " + rhs.getShape().toString());
+    }
+
+    Tensor::Shape shape = rhs.getShape();
+
+    BinaryOpContext ctx;
+    ctx.lhsOffset = 0;
+    ctx.rhsOffset = rhs.getOffset();
+    ctx.count = shape.getNumElements();
+
+    return ctx;
+}
+
+BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor& rhs) {
+    const Tensor& lhsParent = lhs.getParent();
+
+    // must have equal backend
+    if (lhsParent.getBackend() != rhs.getBackend()) {
+        throw std::runtime_error("Can not perform binary operation on tensor views on different devices " 
+            + lhsParent.backendString() + " and " + rhs.backendString() + " of shapes " 
+            + lhs.getShape().toString() + " and " + rhs.shape().toString());
+    }
+
+    // must have equal shapes
+    if (lhs.getShape() != rhs.shape()) {
+        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, "
+            + lhs.getShape().toString() + " and " + rhs.shape().toString());
+    }
+
+    Tensor::Shape shape = rhs.shape();
+
+    BinaryOpContext ctx;
+    ctx.lhsOffset = lhs.getOffset();
+    ctx.rhsOffset = 0;
+    ctx.count = shape.getNumElements();
+
+    return ctx;
+}
 
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs) {
     const Tensor& lhsParent = lhs.getParent();

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -24,7 +24,7 @@ ShapeMatch getShapeRelation(const Tensor::Shape& lhs, const Tensor::Shape& rhs) 
         return ShapeMatch::ScalarRhs;
     }
 
-    if (lhs.getNumElements() == lhs.getNumElements()) {
+    if (lhs.getNumElements() == rhs.getNumElements()) {
         return ShapeMatch::EqualCount;
     }
 
@@ -55,11 +55,13 @@ BinaryOpContext buildContext(const Tensor::View& lhs, const Tensor::View& rhs) {
     Tensor::Shape lhsShape = lhs.getShape();
     Tensor::Shape rhsShape = rhs.getShape();
 
+    ShapeMatch relation = getShapeRelation(lhsShape, rhsShape);
+
     BinaryOpContext ctx;
     ctx.lhsOffset = lhs.getOffset();
     ctx.rhsOffset = rhs.getOffset();
-    ctx.shapeMatch = getShapeRelation(lhsShape, rhsShape);
-    ctx.count = getOperationCount(lhsShape, rhsShape, ctx.shapeMatch);
+    ctx.shapeMatch = relation;
+    ctx.count = getOperationCount(lhsShape, rhsShape, relation);
 
     return ctx;
 }

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -1,9 +1,9 @@
-#include "src/ops/semantic/semantic.h"
+#include "ops/semantic/semantic.h"
 
 
 namespace nforge::semantic {
 
-    
+
 BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor& rhs) {
     // must have equal backend
     if (lhs.getBackend() != rhs.getBackend()) {

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -1,0 +1,61 @@
+#include "src/ops/semantic/semantic.h"
+
+
+namespace nforge::semantic {
+
+    
+BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor& rhs) {
+    // must have equal backend
+    if (lhs.getBackend() != rhs.getBackend()) {
+        throw std::runtime_error("Can not perform binary operation on tensor on different devices " 
+            + lhs.backendString() + " and " + rhs.backendString() + " of shapes " 
+            + lhs.shape().toString() + " and " + rhs.shape().toString());
+    }
+
+    // must have equal shapes
+    if (lhs.shape() != rhs.shape()) {
+        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, "
+            + lhs.shape().toString() + " and " + rhs.shape().toString());
+    }
+
+    Tensor::Shape shape = rhs.shape();
+    
+    BinaryOpContext ctx;
+    ctx.lhsOffset = 0;
+    ctx.rhsOffset = 0;
+    ctx.count = shape.getNumElements();
+
+    return ctx;
+}
+
+
+BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs) {
+    const Tensor& lhsParent = lhs.getParent();
+    const Tensor& rhsParent = rhs.getParent();
+    
+    // must have equal backend
+    if (lhsParent.getBackend() != rhsParent.getBackend()) {
+        throw std::runtime_error("Can not perform binary operation on tensor views on different devices " 
+            + lhsParent.backendString() + " and " + rhsParent.backendString() + " of shapes " 
+            + lhs.getShape().toString() + " and " + rhs.getShape().toString());
+    }
+
+
+    // must have equal shapes
+    if (lhs.getShape() != rhs.getShape()) {
+        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, "
+            + lhs.getShape().toString() + " and " + rhs.getShape().toString());
+    }
+
+    Tensor::Shape shape = rhs.getShape();
+
+    BinaryOpContext ctx;
+    ctx.lhsOffset = lhs.getOffset();
+    ctx.rhsOffset = rhs.getOffset();
+    ctx.count = shape.getNumElements();
+
+    return ctx;
+}
+
+
+} // nforge::semantic

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -4,13 +4,16 @@ namespace nforge::semantic {
 
 void ensureSameBackend(const Tensor& lhs, const Tensor& rhs) {
     if (lhs.getBackend() != rhs.getBackend()) {
-        throw std::runtime_error("Can not perform binary operation on tensor on different devices " + lhs.backendString() + " and " + rhs.backendString() + " of shapes " + lhs.getShape().toString() + " and " + rhs.getShape().toString());
+        throw std::runtime_error("Can not perform binary operation on tensor on different devices " 
+            + lhs.getBackendString() + " and " + rhs.getBackendString() + " of shapes " 
+            + lhs.getShape().toString() + " and " + rhs.getShape().toString());
     }
 }
 
 void ensureSameShape(Tensor::Shape lhsShape, Tensor::Shape rhsShape) {
     if (lhsShape != rhsShape) {
-        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, " + lhsShape.toString() + " and " + rhsShape.toString());
+        throw std::runtime_error("Can not perform binary operations on tensors of different shapes, " 
+            + lhsShape.toString() + " and " + rhsShape.toString());
     }
 }
 
@@ -43,9 +46,9 @@ size_t getOperationCount(const Tensor::Shape& lhs, const Tensor::Shape& rhs, Sha
         case ShapeMatch::Equal:
             return cntLhs;
         case ShapeMatch::ScalarLhs:
-            return cntLhs;
-        case ShapeMatch::ScalarRhs:
             return cntRhs;
+        case ShapeMatch::ScalarRhs:
+            return cntLhs;
         case ShapeMatch::EqualCount:
             return cntLhs;
         case ShapeMatch::Incompatible:
@@ -56,11 +59,14 @@ size_t getOperationCount(const Tensor::Shape& lhs, const Tensor::Shape& rhs, Sha
 }
 
 BinaryOpContext buildContext(const Tensor::View& lhs, const Tensor::View& rhs) {
+    Tensor::Shape lhsShape = lhs.getShape();
+    Tensor::Shape rhsShape = rhs.getShape();
+
     BinaryOpContext ctx;
     ctx.lhsOffset = lhs.getOffset();
     ctx.rhsOffset = rhs.getOffset();
-    ctx.shapeMatch = getShapeRelation(lhs.getShape(), rhs.getShape());
-    ctx.count = getOperationCount(lhs.getShape(), rhs.getShape(), ctx.shapeMatch);
+    ctx.shapeMatch = getShapeRelation(lhsShape, rhsShape);
+    ctx.count = getOperationCount(lhsShape, rhsShape, ctx.shapeMatch);
 
     return ctx;
 }
@@ -78,10 +84,7 @@ BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor& r
 }
 
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs) {
-    const Tensor& lhsParent = lhs.getParent();
-    const Tensor& rhsParent = rhs.getParent();
-
-    ensureSameBackend(lhsParent, rhsParent);
+    ensureSameBackend(lhs.getParent(), rhs.getParent());
 
     return buildContext(lhs, rhs);
 }

--- a/src/ops/semantic/semantic.h
+++ b/src/ops/semantic/semantic.h
@@ -1,0 +1,23 @@
+#ifndef SEMANTIC_H
+#define SEMANTIC_H
+
+#include "nforge/core/tensor.h"
+
+namespace nforge::semantic {
+
+struct BinaryOpContext {
+    size_t lhsOffset = 0;
+    size_t rhsOffset = 0;
+    size_t count = 0;
+};
+
+
+BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor& rhs);
+
+BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs);
+
+
+} // nforge::semantic
+
+
+#endif // SEMANTIC_H

--- a/src/ops/semantic/semantic.h
+++ b/src/ops/semantic/semantic.h
@@ -7,11 +7,11 @@ namespace nforge::semantic {
 
 // sorted by precedence, examples show shape array
 enum class ShapeMatch {
-    Equal,          // [2,3,4] vs [2,3,4]
-    ScalarLhs,      // [1] vs [2,3,4]
-    ScalarRhs,      // [2,3,4] vs [1]
-    EqualCount,     // [12] vs [3,4] (same total elements, different shape)
-    Incompatible    // no other match 
+    Equal,        // [2,3,4] vs [2,3,4]
+    ScalarLhs,    // [1] vs [2,3,4]
+    ScalarRhs,    // [2,3,4] vs [1]
+    EqualCount,   // [12] vs [3,4] (same total elements, different shape)
+    Incompatible  // no other match
 };
 
 struct BinaryOpContext {
@@ -28,10 +28,8 @@ BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor::View& r
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor& rhs);
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs);
 
+BinaryOpContext buildContext(const Tensor::View& lhs, const Tensor::View& rhs);
 
-BinaryOpContext buildContext(const Tensor::View & lhs, const Tensor::View & rhs);
+}  // namespace nforge::semantic
 
-} // nforge::semantic
-
-
-#endif // SEMANTIC_H
+#endif  // SEMANTIC_H

--- a/src/ops/semantic/semantic.h
+++ b/src/ops/semantic/semantic.h
@@ -3,7 +3,7 @@
 
 #include "nforge/core/tensor.h"
 
-namespace nforge::semantic {
+namespace semantic {
 
 // sorted by precedence, examples show shape array
 enum class ShapeMatch {
@@ -30,6 +30,6 @@ BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::V
 
 BinaryOpContext buildContext(const Tensor::View& lhs, const Tensor::View& rhs);
 
-}  // namespace nforge::semantic
+}  // namespace semantic
 
 #endif  // SEMANTIC_H

--- a/src/ops/semantic/semantic.h
+++ b/src/ops/semantic/semantic.h
@@ -13,9 +13,9 @@ struct BinaryOpContext {
 
 
 BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor& rhs);
-
+BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor::View& rhs);
+BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor& rhs);
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs);
-
 
 } // nforge::semantic
 

--- a/src/ops/semantic/semantic.h
+++ b/src/ops/semantic/semantic.h
@@ -5,17 +5,31 @@
 
 namespace nforge::semantic {
 
+// sorted by precedence, examples show shape array
+enum class ShapeMatch {
+    Equal,          // [2,3,4] vs [2,3,4]
+    ScalarLhs,      // [1] vs [2,3,4]
+    ScalarRhs,      // [2,3,4] vs [1]
+    EqualCount,     // [12] vs [3,4] (same total elements, different shape)
+    Incompatible    // no other match 
+};
+
 struct BinaryOpContext {
     size_t lhsOffset = 0;
     size_t rhsOffset = 0;
     size_t count = 0;
+    ShapeMatch shapeMatch = ShapeMatch::Incompatible;
 };
 
+ShapeMatch getShapeRelation(const Tensor::Shape& lhs, const Tensor::Shape& rhs);
 
 BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor& rhs);
 BinaryOpContext validateBinaryOperation(const Tensor& lhs, const Tensor::View& rhs);
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor& rhs);
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs);
+
+
+BinaryOpContext buildContext(const Tensor::View & lhs, const Tensor::View & rhs);
 
 } // nforge::semantic
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,13 +12,16 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Catch2)
 
+
 # Add all test files
 file(GLOB TEST_SOURCES "*.cpp")
 
 
 # Build test binary
 add_executable(test_nforge ${TEST_SOURCES})
+target_include_directories(test_nforge PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(test_nforge PRIVATE NForge Catch2::Catch2WithMain)
+
 
 # Enable testing and add Catch2 tests to CTest
 include(CTest)

--- a/tests/test_semantic.cpp
+++ b/tests/test_semantic.cpp
@@ -1,0 +1,66 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "nforge/core/tensor.h"
+#include "ops/semantic/semantic.h"
+
+TEST_CASE("Correct return values for tensor", "[semantic]") {
+	Tensor a({3}, 4.0f, Backend::CPU), b({3}, 4.0f, Backend::CPU);
+
+    auto ctx = nforge::semantic::validateBinaryOperation(a, b);
+
+    REQUIRE(ctx.lhsOffset == 0);
+    REQUIRE(ctx.rhsOffset == 0);
+    REQUIRE(ctx.count == 3);
+}
+
+TEST_CASE("Correct return values for tensor view", "[semantic]") {
+	Tensor a({9, 8}, 4.0f, Backend::CPU), b({11, 8}, 4.0f, Backend::CPU);
+    
+    Tensor::View x = a[4];
+    Tensor::View y = b[9];
+
+    auto ctx = nforge::semantic::validateBinaryOperation(x, y);
+
+    REQUIRE(ctx.lhsOffset == 8 * (4));
+    REQUIRE(ctx.rhsOffset == 8 * (9));
+    REQUIRE(ctx.count == 8);
+}
+
+
+TEST_CASE("Throw on tensor device mismatch", "[semantic]") {
+    Tensor a({3}, 4.0f, Backend::CPU), b({3}, 4.0f, Backend::CUDA);
+
+    REQUIRE_THROWS_AS(nforge::semantic::validateBinaryOperation(a, b), std::runtime_error);
+    CHECK_THROWS_WITH(nforge::semantic::validateBinaryOperation(a, b), Catch::Matchers::ContainsSubstring("different devices"));
+}
+
+TEST_CASE("Throw on tensor view device mismatch", "[semantic]") {
+    Tensor a({3}, 4.0f, Backend::CPU), b({3}, 4.0f, Backend::CUDA);
+
+    Tensor::View x = a[0];
+    Tensor::View y = b[0];
+
+
+    REQUIRE_THROWS_AS(nforge::semantic::validateBinaryOperation(x, y), std::runtime_error);
+    CHECK_THROWS_WITH(nforge::semantic::validateBinaryOperation(x, y), Catch::Matchers::ContainsSubstring("different devices"));
+}
+
+
+TEST_CASE("Throw on tensor shape mismatch", "[semantic]") {
+    Tensor a({3, 8}, 4.0f, Backend::CPU), b({7, 2}, 4.0f, Backend::CPU);
+
+    REQUIRE_THROWS_AS(nforge::semantic::validateBinaryOperation(a, b), std::runtime_error);
+    CHECK_THROWS_WITH(nforge::semantic::validateBinaryOperation(a, b), Catch::Matchers::ContainsSubstring("different shapes"));
+}
+
+TEST_CASE("Throw on tensor view shape mismatch", "[semantic]") {
+    Tensor a({81, 5}, 4.0f, Backend::CPU), b({3, 99}, 4.0f, Backend::CPU);
+
+    Tensor::View x = a[0];
+    Tensor::View y = b[0];
+
+
+    REQUIRE_THROWS_AS(nforge::semantic::validateBinaryOperation(x, y), std::runtime_error);
+    CHECK_THROWS_WITH(nforge::semantic::validateBinaryOperation(x, y), Catch::Matchers::ContainsSubstring("different shapes"));
+}

--- a/tests/test_semantic.cpp
+++ b/tests/test_semantic.cpp
@@ -109,3 +109,12 @@ TEST_CASE("Throw on tensor view device mismatch", "[semantic]") {
     REQUIRE_THROWS_AS(semantic::validateBinaryOperation(x, y), std::runtime_error);
     CHECK_THROWS_WITH(semantic::validateBinaryOperation(x, y), Catch::Matchers::ContainsSubstring("different devices"));
 }
+
+TEST_CASE("Single element vs Tensor", "[semantic]") {
+    Tensor a({1, 1}, 1.0f, Backend::CPU);
+    Tensor b({3,4}, 1.0f, Backend::CPU);
+
+    auto ctx = semantic::validateBinaryOperation(a, b);
+
+    REQUIRE(ctx.shapeMatch == semantic::ShapeMatch::Incompatible);
+}

--- a/tests/test_semantic.cpp
+++ b/tests/test_semantic.cpp
@@ -5,7 +5,7 @@
 #include "ops/semantic/semantic.h"
 
 TEST_CASE("Correct return values for tensor", "[semantic]") {
-	Tensor a({3}, 4.0f, Backend::CPU), b({3}, 4.0f, Backend::CPU);
+    Tensor a({3}, 4.0f, Backend::CPU), b({3}, 4.0f, Backend::CPU);
 
     auto ctx = nforge::semantic::validateBinaryOperation(a, b);
 
@@ -15,8 +15,8 @@ TEST_CASE("Correct return values for tensor", "[semantic]") {
 }
 
 TEST_CASE("Correct return values for tensor view", "[semantic]") {
-	Tensor a({9, 8}, 4.0f, Backend::CPU), b({11, 8}, 4.0f, Backend::CPU);
-    
+    Tensor a({9, 8}, 4.0f, Backend::CPU), b({11, 8}, 4.0f, Backend::CPU);
+
     Tensor::View x = a[4];
     Tensor::View y = b[9];
 
@@ -26,7 +26,6 @@ TEST_CASE("Correct return values for tensor view", "[semantic]") {
     REQUIRE(ctx.rhsOffset == 8 * (9));
     REQUIRE(ctx.count == 8);
 }
-
 
 TEST_CASE("Throw on tensor device mismatch", "[semantic]") {
     Tensor a({3}, 4.0f, Backend::CPU), b({3}, 4.0f, Backend::CUDA);
@@ -40,7 +39,6 @@ TEST_CASE("Throw on tensor view device mismatch", "[semantic]") {
 
     Tensor::View x = a[0];
     Tensor::View y = b[0];
-
 
     REQUIRE_THROWS_AS(nforge::semantic::validateBinaryOperation(x, y), std::runtime_error);
     CHECK_THROWS_WITH(nforge::semantic::validateBinaryOperation(x, y), Catch::Matchers::ContainsSubstring("different devices"));

--- a/tests/test_semantic.cpp
+++ b/tests/test_semantic.cpp
@@ -45,22 +45,3 @@ TEST_CASE("Throw on tensor view device mismatch", "[semantic]") {
     REQUIRE_THROWS_AS(nforge::semantic::validateBinaryOperation(x, y), std::runtime_error);
     CHECK_THROWS_WITH(nforge::semantic::validateBinaryOperation(x, y), Catch::Matchers::ContainsSubstring("different devices"));
 }
-
-
-TEST_CASE("Throw on tensor shape mismatch", "[semantic]") {
-    Tensor a({3, 8}, 4.0f, Backend::CPU), b({7, 2}, 4.0f, Backend::CPU);
-
-    REQUIRE_THROWS_AS(nforge::semantic::validateBinaryOperation(a, b), std::runtime_error);
-    CHECK_THROWS_WITH(nforge::semantic::validateBinaryOperation(a, b), Catch::Matchers::ContainsSubstring("different shapes"));
-}
-
-TEST_CASE("Throw on tensor view shape mismatch", "[semantic]") {
-    Tensor a({81, 5}, 4.0f, Backend::CPU), b({3, 99}, 4.0f, Backend::CPU);
-
-    Tensor::View x = a[0];
-    Tensor::View y = b[0];
-
-
-    REQUIRE_THROWS_AS(nforge::semantic::validateBinaryOperation(x, y), std::runtime_error);
-    CHECK_THROWS_WITH(nforge::semantic::validateBinaryOperation(x, y), Catch::Matchers::ContainsSubstring("different shapes"));
-}

--- a/tests/test_semantic.cpp
+++ b/tests/test_semantic.cpp
@@ -4,34 +4,100 @@
 #include "nforge/core/tensor.h"
 #include "ops/semantic/semantic.h"
 
-TEST_CASE("Correct return values for tensor", "[semantic]") {
+TEST_CASE("Tensor vs Tensor", "[semantic]") {
     Tensor a({3}, 4.0f, Backend::CPU), b({3}, 4.0f, Backend::CPU);
 
-    auto ctx = nforge::semantic::validateBinaryOperation(a, b);
+    auto ctx = semantic::validateBinaryOperation(a, b);
 
     REQUIRE(ctx.lhsOffset == 0);
     REQUIRE(ctx.rhsOffset == 0);
     REQUIRE(ctx.count == 3);
 }
 
-TEST_CASE("Correct return values for tensor view", "[semantic]") {
+TEST_CASE("Tensor view vs Tensor view", "[semantic]") {
     Tensor a({9, 8}, 4.0f, Backend::CPU), b({11, 8}, 4.0f, Backend::CPU);
 
     Tensor::View x = a[4];
     Tensor::View y = b[9];
 
-    auto ctx = nforge::semantic::validateBinaryOperation(x, y);
+    auto ctx = semantic::validateBinaryOperation(x, y);
 
     REQUIRE(ctx.lhsOffset == 8 * (4));
     REQUIRE(ctx.rhsOffset == 8 * (9));
     REQUIRE(ctx.count == 8);
 }
 
+TEST_CASE("Tensor vs View", "[semantic]") {
+    Tensor a({9,8}, 4.0f, Backend::CPU);
+    Tensor b({8}, 1.0f, Backend::CPU);
+
+    Tensor::View v = a[4];
+
+    auto ctx = semantic::validateBinaryOperation(b, v);
+
+    REQUIRE(ctx.lhsOffset == 0);
+    REQUIRE(ctx.rhsOffset == 8 * 4);
+    REQUIRE(ctx.count == 8);
+    REQUIRE(ctx.shapeMatch == semantic::ShapeMatch::Equal);
+}
+
+TEST_CASE("View vs Tensor", "[semantic]") {
+    Tensor a({9,8}, 4.0f, Backend::CPU);
+    Tensor b({8}, 1.0f, Backend::CPU);
+
+    Tensor::View v = a[6];
+
+    auto ctx = semantic::validateBinaryOperation(v, b);
+
+    REQUIRE(ctx.lhsOffset == 8 * 6);
+    REQUIRE(ctx.rhsOffset == 0);
+    REQUIRE(ctx.count == 8);
+    REQUIRE(ctx.shapeMatch == semantic::ShapeMatch::Equal);
+}
+
+TEST_CASE("Scalar vs Tensor shape", "[semantic]") {
+    Tensor a({3,4}, 1.0f, Backend::CPU);
+    Tensor b({1}, 2.0f, Backend::CPU);
+
+    auto ctx = semantic::validateBinaryOperation(a, b);
+
+    REQUIRE(ctx.lhsOffset == 0);
+    REQUIRE(ctx.rhsOffset == 0);
+    REQUIRE(ctx.count == 12);
+    REQUIRE(ctx.shapeMatch == semantic::ShapeMatch::ScalarRhs);
+}
+
+TEST_CASE("Scalar vs Tensor view", "[semantic]") {
+    Tensor a({1}, 2.0f, Backend::CPU);
+    Tensor b({3, 8, 4}, 1.0f, Backend::CPU);
+
+    Tensor::View v = b[2];
+
+    auto ctx = semantic::validateBinaryOperation(a, v);
+
+    REQUIRE(ctx.lhsOffset == 0);
+    REQUIRE(ctx.rhsOffset == 2 * 8 * 4);
+    REQUIRE(ctx.count == 8 * 4);
+    REQUIRE(ctx.shapeMatch == semantic::ShapeMatch::ScalarLhs);
+}
+
+TEST_CASE("Flat vs Shaped returns EqualCount", "[semantic]") {
+    Tensor a({12}, 1.0f, Backend::CPU);
+    Tensor b({3,4}, 1.0f, Backend::CPU);
+
+    auto ctx = semantic::validateBinaryOperation(a, b);
+
+    REQUIRE(ctx.lhsOffset == 0);
+    REQUIRE(ctx.rhsOffset == 0);
+    REQUIRE(ctx.count == 12);    
+    REQUIRE(ctx.shapeMatch == semantic::ShapeMatch::EqualCount);
+}
+
 TEST_CASE("Throw on tensor device mismatch", "[semantic]") {
     Tensor a({3}, 4.0f, Backend::CPU), b({3}, 4.0f, Backend::CUDA);
 
-    REQUIRE_THROWS_AS(nforge::semantic::validateBinaryOperation(a, b), std::runtime_error);
-    CHECK_THROWS_WITH(nforge::semantic::validateBinaryOperation(a, b), Catch::Matchers::ContainsSubstring("different devices"));
+    REQUIRE_THROWS_AS(semantic::validateBinaryOperation(a, b), std::runtime_error);
+    CHECK_THROWS_WITH(semantic::validateBinaryOperation(a, b), Catch::Matchers::ContainsSubstring("different devices"));
 }
 
 TEST_CASE("Throw on tensor view device mismatch", "[semantic]") {
@@ -40,6 +106,6 @@ TEST_CASE("Throw on tensor view device mismatch", "[semantic]") {
     Tensor::View x = a[0];
     Tensor::View y = b[0];
 
-    REQUIRE_THROWS_AS(nforge::semantic::validateBinaryOperation(x, y), std::runtime_error);
-    CHECK_THROWS_WITH(nforge::semantic::validateBinaryOperation(x, y), Catch::Matchers::ContainsSubstring("different devices"));
+    REQUIRE_THROWS_AS(semantic::validateBinaryOperation(x, y), std::runtime_error);
+    CHECK_THROWS_WITH(semantic::validateBinaryOperation(x, y), Catch::Matchers::ContainsSubstring("different devices"));
 }

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -9,6 +9,42 @@ TEST_CASE("Create tensor", "[tensor]") {
 	REQUIRE(t.backendString() == "CPU");
 }
 
+TEST_CASE("Compare tensor", "[tensor]") {
+	Tensor a({3, 9, 7}, 19.0f, Backend::CPU);
+	Tensor b({3, 9, 7}, 19.0f, Backend::CPU);
+
+	REQUIRE(a == b);
+	REQUIRE(b == a);
+}
+
+TEST_CASE("Compare tensor views", "[tensor]") {
+	Tensor a({3, 9, 7}, 19.0f, Backend::CPU);
+	Tensor b({3, 9, 7}, 19.0f, Backend::CPU);
+
+	auto x = a[0];
+	auto y = b[0];
+
+	REQUIRE(x == y);
+	REQUIRE(y == x);
+}
+
+TEST_CASE("Compare tensor and tensor view", "[tensor]") {
+	Tensor a({3, 9, 7}, 19.0f, Backend::CPU);
+	Tensor b({9, 7}, 19.0f, Backend::CPU);
+
+	auto x = a[0];
+	auto y = a[1];
+
+	REQUIRE(x == b);
+	REQUIRE(x == y);
+	
+	REQUIRE(b == x);
+	REQUIRE(b == y);
+
+	REQUIRE(y == x);
+	REQUIRE(y == b);
+}
+
 TEST_CASE("Add tensors", "[tensor]") {
 	Tensor a({3}, 4.0f, Backend::CPU);
 	Tensor b({3}, 1.0f, Backend::CPU);
@@ -42,14 +78,13 @@ TEST_CASE("Broadcast scalar add", "[tensor]") {
 	Tensor s(3.0f);
 
 	Tensor c = a + s;
-
-	REQUIRE(c[0] == Tensor(5));
-	REQUIRE(c[3] == Tensor(5));
+	
+	REQUIRE(c[2] == Tensor(5));
 }
 
 TEST_CASE("2D tensor shape and indexing", "[tensor]") {
-	auto rows = GENERATE(1uz, 4uz, 10uz);
-	auto cols = GENERATE(1uz, 10uz, 50uz);
+	auto rows = GENERATE(1ull, 4ull, 10ull);
+	auto cols = GENERATE(1ull, 10ull, 50ull);
 	auto val = GENERATE(-1001.0f, 0.32f, 122.9f);
 
 	DYNAMIC_SECTION("rows=" << rows << " cols=" << cols << " val=" << val) {
@@ -72,8 +107,8 @@ TEST_CASE("2D tensor shape and indexing", "[tensor]") {
 }
 
 TEST_CASE("Tensor slice assign", "[tensor]") {
-	auto rows = GENERATE(1uz, 2uz, 3uz);
-	auto cols = GENERATE(1uz, 4uz, 8uz);
+	auto rows = GENERATE(1ull, 2ull, 3ull);
+	auto cols = GENERATE(1ull, 4ull, 8ull);
 	auto val = GENERATE(0.0f, 1.5f);
 
 	DYNAMIC_SECTION("rows=" << rows << " cols=" << cols << " val=" << val) {
@@ -94,7 +129,8 @@ TEST_CASE("Tensor slice assign", "[tensor]") {
 				REQUIRE(A[i][j] == B[i][j]);
 			}
 		}
-
+		
+		INFO("A=" + A.dataString() + "\nB=" + B.dataString());
 		REQUIRE(A == B);
 	}
 }

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -1,139 +1,137 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
+
 #include "nforge/core/tensor.h"
 
 TEST_CASE("Create tensor", "[tensor]") {
-	Tensor t({3}, 4.0f, Backend::CPU);
+    Tensor t({3}, 4.0f, Backend::CPU);
 
-	REQUIRE(t.numElements() == 3);
-	REQUIRE(t.backendString() == "CPU");
+    REQUIRE(t.getNumElements() == 3);
+    REQUIRE(t.getBackendString() == "CPU");
 }
 
 TEST_CASE("Compare tensor", "[tensor]") {
-	Tensor a({3, 9, 7}, 19.0f, Backend::CPU);
-	Tensor b({3, 9, 7}, 19.0f, Backend::CPU);
-	Tensor c({3, 7, 9}, 19.0f, Backend::CPU);
+    Tensor a({3, 9, 7}, 19.0f, Backend::CPU);
+    Tensor b({3, 9, 7}, 19.0f, Backend::CPU);
+    Tensor c({3, 7, 9}, 19.0f, Backend::CPU);
 
-	REQUIRE(a == b);
-	REQUIRE(b == a);
-	REQUIRE(c != a);
-	REQUIRE(c != b);
+    REQUIRE(a == b);
+    REQUIRE(b == a);
+    REQUIRE(c != a);
+    REQUIRE(c != b);
 }
 
 TEST_CASE("Compare tensor views", "[tensor]") {
-	Tensor a({3, 9, 7}, 19.0f, Backend::CPU);
-	Tensor b({3, 9, 7}, 19.0f, Backend::CPU);
+    Tensor a({3, 9, 7}, 19.0f, Backend::CPU);
+    Tensor b({3, 9, 7}, 19.0f, Backend::CPU);
 
-	auto x = a[0];
-	auto y = b[0];
+    auto x = a[0];
+    auto y = b[0];
 
-	REQUIRE(x == y);
-	REQUIRE(y == x);
+    REQUIRE(x == y);
+    REQUIRE(y == x);
 }
 
 TEST_CASE("Compare tensor and tensor view", "[tensor]") {
-	Tensor a({3, 9, 7}, 19.0f, Backend::CPU);
-	Tensor b({9, 7}, 19.0f, Backend::CPU);
+    Tensor a({3, 9, 7}, 19.0f, Backend::CPU);
+    Tensor b({9, 7}, 19.0f, Backend::CPU);
 
-	auto x = a[0];
-	auto y = a[1];
+    auto x = a[0];
+    auto y = a[1];
 
-	REQUIRE(x == b);
-	REQUIRE(x == y);
-	
-	REQUIRE(b == x);
-	REQUIRE(b == y);
+    REQUIRE(x == b);
+    REQUIRE(x == y);
 
-	REQUIRE(y == x);
-	REQUIRE(y == b);
+    REQUIRE(b == x);
+    REQUIRE(b == y);
+
+    REQUIRE(y == x);
+    REQUIRE(y == b);
 }
 
 TEST_CASE("Add tensors", "[tensor]") {
-	Tensor a({3}, 4.0f, Backend::CPU);
-	Tensor b({3}, 1.0f, Backend::CPU);
+    Tensor a({3}, 4.0f, Backend::CPU);
+    Tensor b({3}, 1.0f, Backend::CPU);
 
-	Tensor c = a + b;
+    Tensor c = a + b;
 
-	REQUIRE(c[0] == Tensor(5));
-	REQUIRE(c[0] == c[1]);
-	REQUIRE(c[1] == c[2]);
-	REQUIRE(c[0] != Tensor(3));
+    REQUIRE(c[0] == Tensor(5));
+    REQUIRE(c[0] == c[1]);
+    REQUIRE(c[1] == c[2]);
+    REQUIRE(c[0] != Tensor(3));
 }
 
 TEST_CASE("Subtract and multiply tensors", "[tensor]") {
-	Tensor a({3}, 4.0f, Backend::CPU);
-	Tensor b({3}, 1.0f, Backend::CPU);
+    Tensor a({3}, 4.0f, Backend::CPU);
+    Tensor b({3}, 1.0f, Backend::CPU);
 
-	Tensor sub = a - b;
-	Tensor mul = a * b;
+    Tensor sub = a - b;
+    Tensor mul = a * b;
 
-	REQUIRE(sub[0] == Tensor(3));
-	REQUIRE(sub[0] == sub[1]);
-	REQUIRE(sub[1] == sub[2]);
+    REQUIRE(sub[0] == Tensor(3));
+    REQUIRE(sub[0] == sub[1]);
+    REQUIRE(sub[1] == sub[2]);
 
-	REQUIRE(mul[0] == Tensor(4));
-	REQUIRE(mul[0] == mul[1]);
-	REQUIRE(mul[1] == mul[2]);
+    REQUIRE(mul[0] == Tensor(4));
+    REQUIRE(mul[0] == mul[1]);
+    REQUIRE(mul[1] == mul[2]);
 }
 
 TEST_CASE("Broadcast scalar add", "[tensor]") {
-	Tensor a({4}, 2.0f, Backend::CPU);
-	Tensor s(3.0f);
+    Tensor a({4}, 2.0f, Backend::CPU);
+    Tensor s(3.0f);
 
-	Tensor c = a + s;
-	
-	REQUIRE(c[2] == Tensor(5));
+    Tensor c = a + s;
+
+    REQUIRE(c[2] == Tensor(5));
 }
 
 TEST_CASE("2D tensor shape and indexing", "[tensor]") {
-	auto rows = GENERATE(1ull, 4ull, 10ull);
-	auto cols = GENERATE(1ull, 10ull, 50ull);
-	auto val = GENERATE(-1001.0f, 0.32f, 122.9f);
+    auto rows = GENERATE(1ull, 4ull, 10ull);
+    auto cols = GENERATE(1ull, 10ull, 50ull);
+    auto val = GENERATE(-1001.0f, 0.32f, 122.9f);
 
-	DYNAMIC_SECTION("rows=" << rows << " cols=" << cols << " val=" << val) {
-		Tensor a({rows, cols}, val, Backend::CPU);
+    DYNAMIC_SECTION("rows=" << rows << " cols=" << cols << " val=" << val) {
+        Tensor a({rows, cols}, val, Backend::CPU);
 
-		// Check number of elements
-		REQUIRE(a.numElements() == rows * cols);
+        // Check number of elements
+        REQUIRE(a.getNumElements() == rows * cols);
 
+        // Compare slices
+        REQUIRE(a[0] == Tensor({cols}, val, Backend::CPU));
+        REQUIRE(a[0][0] == Tensor(val));
+        REQUIRE(a[0][0] != Tensor(val - 1));
 
-		// Compare slices
-		REQUIRE(a[0] == Tensor({cols}, val, Backend::CPU));
-		REQUIRE(a[0][0] == Tensor(val));
-		REQUIRE(a[0][0] != Tensor(val - 1));
+        REQUIRE_FALSE(a[0][0] != Tensor(val));
+        REQUIRE_FALSE(a[0][0] == Tensor(val - 1));
 
-		REQUIRE_FALSE(a[0][0] != Tensor(val));
-		REQUIRE_FALSE(a[0][0] == Tensor(val - 1));
-
-		REQUIRE(a[0] == a[rows - 1]);
-	}
+        REQUIRE(a[0] == a[rows - 1]);
+    }
 }
 
 TEST_CASE("Tensor slice assign", "[tensor]") {
-	auto rows = GENERATE(1ull, 2ull, 3ull);
-	auto cols = GENERATE(1ull, 4ull, 8ull);
-	auto val = GENERATE(0.0f, 1.5f);
+    auto rows = GENERATE(1ull, 2ull, 3ull);
+    auto cols = GENERATE(1ull, 4ull, 8ull);
+    auto val = GENERATE(0.0f, 1.5f);
 
-	DYNAMIC_SECTION("rows=" << rows << " cols=" << cols << " val=" << val) {
-		
-		// Create A and random B
-		Tensor A({rows, cols}, val, Backend::CPU);
-		Tensor B({rows, cols}, Backend::CPU);
-		B.fillRand();
-		
-		// Slice copy
-		for (size_t i = 0; i < rows; i++) {
-			A[i] = B[i];
-		}
+    DYNAMIC_SECTION("rows=" << rows << " cols=" << cols << " val=" << val) {
+        // Create A and random B
+        Tensor A({rows, cols}, val, Backend::CPU);
+        Tensor B({rows, cols}, Backend::CPU);
+        B.fillRand();
 
-		// Element wise compare
-		for (size_t i = 0; i < rows; i++) {
-			for (size_t j = 0; j < cols; j++) {
-				REQUIRE(A[i][j] == B[i][j]);
-			}
-		}
-		
-		INFO("A=" + A.dataString() + "\nB=" + B.dataString());
-		REQUIRE(A == B);
-	}
+        // Slice copy
+        for (size_t i = 0; i < rows; i++) {
+            A[i] = B[i];
+        }
+
+        // Element wise compare
+        for (size_t i = 0; i < rows; i++) {
+            for (size_t j = 0; j < cols; j++) {
+                REQUIRE(A[i][j] == B[i][j]);
+            }
+        }
+
+        REQUIRE(A == B);
+    }
 }

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -81,9 +81,18 @@ TEST_CASE("Broadcast scalar add", "[tensor]") {
     Tensor a({4}, 2.0f, Backend::CPU);
     Tensor s(3.0f);
 
-    Tensor c = a + s;
+    Tensor x = a + s;
+    Tensor y = s + a;
 
-    REQUIRE(c[2] == Tensor(5));
+	INFO("a=" + a.getDataString());
+	INFO("s=" + s.getDataString());
+	INFO("x=" + x.getDataString());
+	INFO("y=" + y.getDataString());
+
+	for (size_t i = 0; i < 4; i++) {
+		REQUIRE(x[i] == Tensor(5));
+    	REQUIRE(y[i] == Tensor(5));
+	}
 }
 
 TEST_CASE("2D tensor shape and indexing", "[tensor]") {

--- a/tests/test_tensor.cpp
+++ b/tests/test_tensor.cpp
@@ -12,9 +12,12 @@ TEST_CASE("Create tensor", "[tensor]") {
 TEST_CASE("Compare tensor", "[tensor]") {
 	Tensor a({3, 9, 7}, 19.0f, Backend::CPU);
 	Tensor b({3, 9, 7}, 19.0f, Backend::CPU);
+	Tensor c({3, 7, 9}, 19.0f, Backend::CPU);
 
 	REQUIRE(a == b);
 	REQUIRE(b == a);
+	REQUIRE(c != a);
+	REQUIRE(c != b);
 }
 
 TEST_CASE("Compare tensor views", "[tensor]") {


### PR DESCRIPTION
# Move semantic validation from CPUImpl to Tensor layer

## Problem

Closes #1 
In short `Tensor::CPUImpl::compare` currently performs semantic operations that violate the intended layering architecture.

### Previous layering:
- Tensor validates backend only
- CPUImpl validates shapes, computes offsets, executes


### New layering:
- Tensor validates everything, computes offsets
- CPUImpl assumes valid inputs and just executes


## Changes

### 1. Introduced semantic layer
- Validates backend
- Computes offsets and element count
- Returns shape relation between tensors, see ``ShapeMatch``


### 2. Moved responsibilities
- **Tensor layer**: All validation, offset calculation, shape slicing
- **CPUImpl layer**: Raw memory operations only
- **Replaced** `dynamic_cast` with `static_cast` (safe after Tensor validation)