### PR TITLE
Tensor and tensor view arithmetic operations

### DIFF
--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -61,36 +61,36 @@ class Tensor {
     std::vector<float> toVector() const;
 
     // Set the specified block to another tensor
-    void set(const std::vector<size_t>& position, const Tensor& other);
-    void set(const std::vector<size_t>& position, const Tensor::View& other);
+    void set(const std::vector<size_t>& position, const Tensor& rhs);
+    void set(const std::vector<size_t>& position, const Tensor::View& rhs);
 
-    bool compare(const Tensor& other) const;
-    bool compare(const Tensor::View& other) const;
+    bool compare(const Tensor& rhs) const;
+    bool compare(const Tensor::View& rhs) const;
 
     // Compare the specified block to another tensor
-    bool compare(const std::vector<size_t>& position, const Tensor& other) const;
-    bool compare(const std::vector<size_t>& position, const Tensor::View& other) const;
+    bool compare(const std::vector<size_t>& position, const Tensor& rhs) const;
+    bool compare(const std::vector<size_t>& position, const Tensor::View& rhs) const;
 
     // Overloaded operators
-    Tensor operator+(const Tensor& other) const;
-    Tensor operator-(const Tensor& other) const;
-    Tensor operator*(const Tensor& other) const;
-    Tensor operator/(const Tensor& other) const;
+    Tensor operator+(const Tensor& rhs) const;
+    Tensor operator-(const Tensor& rhs) const;
+    Tensor operator*(const Tensor& rhs) const;
+    Tensor operator/(const Tensor& rhs) const;
 
-    Tensor operator+(const Tensor::View& other) const;
-    Tensor operator-(const Tensor::View& other) const;
-    Tensor operator*(const Tensor::View& other) const;
-    Tensor operator/(const Tensor::View& other) const;
+    Tensor operator+(const Tensor::View& rhs) const;
+    Tensor operator-(const Tensor::View& rhs) const;
+    Tensor operator*(const Tensor::View& rhs) const;
+    Tensor operator/(const Tensor::View& rhs) const;
 
     
     Tensor::View operator[](size_t idx) const;
 
-    Tensor operator=(const Tensor& other);
+    Tensor operator=(const Tensor& rhs);
 
-    bool operator==(const Tensor& other) const;
-    bool operator==(const Tensor::View& other) const;
-    bool operator!=(const Tensor& other) const;
-    bool operator!=(const Tensor::View& other) const;
+    bool operator==(const Tensor& rhs) const;
+    bool operator==(const Tensor::View& rhs) const;
+    bool operator!=(const Tensor& rhs) const;
+    bool operator!=(const Tensor::View& rhs) const;
 
    private:
     Backend m_backend;

--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -98,7 +98,7 @@ class Tensor {
 
     // used in template for all the binary operations
     template <typename EqualOp, typename ScalarOp>
-    Tensor applyBinaryOp(const Tensor& rhs, const std::string& opName, EqualOp equalOp, ScalarOp scalarOp) const;
+    Tensor applyBinaryOp(const Tensor::View& rhs, const std::string& opName, EqualOp equalOp, ScalarOp scalarOp) const;
 };
 
 #include "backend/tensor_impl.h"

--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -77,6 +77,12 @@ class Tensor {
     Tensor operator*(const Tensor& other) const;
     Tensor operator/(const Tensor& other) const;
 
+    Tensor operator+(const Tensor::View& other) const;
+    Tensor operator-(const Tensor::View& other) const;
+    Tensor operator*(const Tensor::View& other) const;
+    Tensor operator/(const Tensor::View& other) const;
+
+    
     Tensor::View operator[](size_t idx) const;
 
     Tensor operator=(const Tensor& other);

--- a/include/nforge/core/tensor_view.h
+++ b/include/nforge/core/tensor_view.h
@@ -22,6 +22,19 @@ class Tensor::View {
     // shape of the view
     Tensor::Shape getShape() const;
 
+    // creates a copy of the viewed tensor
+    Tensor copy() const;
+
+    Tensor operator+(const Tensor& rhs) const;
+    Tensor operator-(const Tensor& rhs) const;
+    Tensor operator*(const Tensor& rhs) const;
+    Tensor operator/(const Tensor& rhs) const;
+
+    Tensor operator+(const Tensor::View& rhs) const;
+    Tensor operator-(const Tensor::View& rhs) const;
+    Tensor operator*(const Tensor::View& rhs) const;
+    Tensor operator/(const Tensor::View& rhs) const;
+
     Tensor operator=(const Tensor& other);
     Tensor operator=(const Tensor::View& other);
     Tensor::View operator[](size_t idx) const;

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -203,6 +203,24 @@ Tensor Tensor::operator/(const Tensor& rhs) const {
     return applyBinaryOp(rhs, "div", &Tensor::Impl::div, &Tensor::Impl::divScalar);
 }
 
+
+Tensor Tensor::operator+(const Tensor::View& rhs) const {
+    return Tensor(1);
+}
+
+Tensor Tensor::operator-(const Tensor::View& rhs) const {
+    return Tensor(1);
+}
+
+Tensor Tensor::operator*(const Tensor::View& rhs) const {
+    return Tensor(1);
+}
+
+Tensor Tensor::operator/(const Tensor::View& rhs) const {
+    return Tensor(1);
+}
+
+
 Tensor::View Tensor::operator[](size_t idx) const {
     Tensor::View results((Tensor&)*this, {idx});
     return results;

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -42,8 +42,8 @@ Tensor::Tensor(float value, Backend backend)
     : Tensor(Tensor::Shape({1}), value, backend) {
 }
 
-Tensor::Tensor(const Tensor& other)
-    : m_backend(other.m_backend), m_impl(other.m_impl->clone()) {
+Tensor::Tensor(const Tensor& rhs)
+    : m_backend(rhs.m_backend), m_impl(rhs.m_impl->clone()) {
 }
 
 Tensor::Tensor(std::unique_ptr<Tensor::Impl> impl, Backend backend)

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -163,21 +163,23 @@ bool Tensor::compare(const std::vector<size_t>& position, const Tensor::View& rh
 }
 
 template <typename EqualOp, typename ScalarOp>
-Tensor Tensor::applyBinaryOp(const Tensor& rhs, const std::string& opName, EqualOp equalOp, ScalarOp scalarOp) const {
+Tensor Tensor::applyBinaryOp(const Tensor::View& rhs, const std::string& opName, EqualOp equalOp, ScalarOp scalarOp) const {
     auto ctx = semantic::validateBinaryOperation(*this, rhs);
+
+    std::unique_ptr<Tensor::Impl>& rhsImpl = rhs.getParent().m_impl;
 
     std::unique_ptr<Tensor::Impl> results;
     switch (ctx.shapeMatch) {
         case semantic::ShapeMatch::Equal:
-            results = (m_impl.get()->*equalOp)(ctx.lhsOffset, rhs.m_impl.get(), ctx.rhsOffset, ctx.count);
+            results = (m_impl.get()->*equalOp)(ctx.lhsOffset, rhsImpl.get(), ctx.rhsOffset, ctx.count);
             break;
 
         case semantic::ShapeMatch::ScalarLhs:
-            results = (rhs.m_impl.get()->*scalarOp)(ctx.rhsOffset, m_impl.get(), ctx.count);
+            results = (rhsImpl.get()->*scalarOp)(ctx.rhsOffset, m_impl.get(), ctx.count);
             break;
 
         case semantic::ShapeMatch::ScalarRhs:
-            results = (m_impl.get()->*scalarOp)(ctx.lhsOffset, rhs.m_impl.get(), ctx.count);
+            results = (m_impl.get()->*scalarOp)(ctx.lhsOffset, rhsImpl.get(), ctx.count);
             break;
 
         default:
@@ -205,19 +207,19 @@ Tensor Tensor::operator/(const Tensor& rhs) const {
 
 
 Tensor Tensor::operator+(const Tensor::View& rhs) const {
-    return Tensor(1);
+    return applyBinaryOp(rhs, "add", &Tensor::Impl::add, &Tensor::Impl::addScalar);
 }
 
 Tensor Tensor::operator-(const Tensor::View& rhs) const {
-    return Tensor(1);
+    return applyBinaryOp(rhs, "sub", &Tensor::Impl::sub, &Tensor::Impl::subScalar);
 }
 
 Tensor Tensor::operator*(const Tensor::View& rhs) const {
-    return Tensor(1);
+    return applyBinaryOp(rhs, "mul", &Tensor::Impl::mul, &Tensor::Impl::mulScalar);
 }
 
 Tensor Tensor::operator/(const Tensor::View& rhs) const {
-    return Tensor(1);
+    return applyBinaryOp(rhs, "div", &Tensor::Impl::div, &Tensor::Impl::divScalar);
 }
 
 

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -57,36 +57,44 @@ Tensor Tensor::View::copy() const {
 
 
 Tensor Tensor::View::operator+(const Tensor& rhs) const {
-    return Tensor({1});
+    Tensor current = copy();
+    return current + rhs;
 }
 
 Tensor Tensor::View::operator-(const Tensor& rhs) const {
-    return Tensor({1});
+    Tensor current = copy();
+    return current - rhs;
 }
 
 Tensor Tensor::View::operator*(const Tensor& rhs) const {
-    return Tensor({1});
+    Tensor current = copy();
+    return current * rhs;
 }
 
 Tensor Tensor::View::operator/(const Tensor& rhs) const {
-    return Tensor({1});
+    Tensor current = copy();
+    return current / rhs;
 }
 
 
 Tensor Tensor::View::operator+(const Tensor::View& rhs) const {
-    return Tensor({1});
+    Tensor current = copy();
+    return current + rhs;
 }
 
 Tensor Tensor::View::operator-(const Tensor::View& rhs) const {
-    return Tensor({1});
+    Tensor current = copy();
+    return current - rhs;
 }
 
 Tensor Tensor::View::operator*(const Tensor::View& rhs) const {
-    return Tensor({1});
+    Tensor current = copy();
+    return current * rhs;
 }
 
 Tensor Tensor::View::operator/(const Tensor::View& rhs) const {
-    return Tensor({1});
+    Tensor current = copy();
+    return current / rhs;
 }
 
 

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -50,17 +50,45 @@ Tensor Tensor::View::copy() const {
 
     // set the whole tensor
     std::vector<size_t> position = {};
-
-    std::cout << "before set:\n";
-    copy.print();
-
     copy.set(position, *this);
-
-    std::cout << "after set:\n";
-    copy.print();
 
     return copy;
 } 
+
+
+Tensor Tensor::View::operator+(const Tensor& rhs) const {
+    return Tensor({1});
+}
+
+Tensor Tensor::View::operator-(const Tensor& rhs) const {
+    return Tensor({1});
+}
+
+Tensor Tensor::View::operator*(const Tensor& rhs) const {
+    return Tensor({1});
+}
+
+Tensor Tensor::View::operator/(const Tensor& rhs) const {
+    return Tensor({1});
+}
+
+
+Tensor Tensor::View::operator+(const Tensor::View& rhs) const {
+    return Tensor({1});
+}
+
+Tensor Tensor::View::operator-(const Tensor::View& rhs) const {
+    return Tensor({1});
+}
+
+Tensor Tensor::View::operator*(const Tensor::View& rhs) const {
+    return Tensor({1});
+}
+
+Tensor Tensor::View::operator/(const Tensor::View& rhs) const {
+    return Tensor({1});
+}
+
 
 Tensor Tensor::View::operator=(const Tensor& lhs) {
     m_parent.set(m_position, lhs);

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -43,6 +43,25 @@ Tensor::Shape Tensor::View::getShape() const {
     return m_parent.getShape()[m_position];
 }
 
+Tensor Tensor::View::copy() const {
+    auto shape = getShape();
+    auto backend = getParent().getBackend();
+    Tensor copy(shape, backend);
+
+    // set the whole tensor
+    std::vector<size_t> position = {};
+
+    std::cout << "before set:\n";
+    copy.print();
+
+    copy.set(position, *this);
+
+    std::cout << "after set:\n";
+    copy.print();
+
+    return copy;
+} 
+
 Tensor Tensor::View::operator=(const Tensor& lhs) {
     m_parent.set(m_position, lhs);
     return m_parent;

--- a/tests/test_view_arithemtic.cpp
+++ b/tests/test_view_arithemtic.cpp
@@ -2,7 +2,7 @@
 // Tests for: Tensor and Tensor View arithmetic operations
 //
 // Covers:
-//   1. TensorView::copy() — converting a view back to an owned Tensor
+//   1. TensorView::copy() - converting a view back to an owned Tensor
 //   2. TensorView <op> TensorView arithmetic
 //   3. Tensor <op> TensorView  and  TensorView <op> Tensor arithmetic
 // =============================================================================
@@ -25,6 +25,9 @@ TEST_CASE("TensorView copy produces an independent Tensor", "[TensorView][Copy]"
 
     DYNAMIC_SECTION(getBackendString(backend)) {
         Tensor src({3, 4}, 7.0f, backend);
+
+        std::cout << "src:\n";
+        src.print();
         auto   view = src[1];              // view of row-1 (4 elements)
         Tensor copy = view.copy();
 
@@ -38,7 +41,7 @@ TEST_CASE("TensorView copy produces an independent Tensor", "[TensorView][Copy]"
     }
 }
 
-TEST_CASE("TensorView copy is a deep copy — mutations are independent", "[TensorView][Copy]") {
+TEST_CASE("TensorView copy is a deep copy", "[TensorView][Copy]") {
     auto backend = GENERATE(from_range(backends));
 
     DYNAMIC_SECTION(getBackendString(backend)) {
@@ -46,7 +49,7 @@ TEST_CASE("TensorView copy is a deep copy — mutations are independent", "[Tens
         auto   view = src[0];             // scalar view
         Tensor copy = view.copy();
 
-        // Mutate the source — copy must be unaffected
+        // Mutate the source and copy must be unaffected
         src = Tensor({4}, 99.0f, backend);
         REQUIRE(copy == Tensor(1.0f, backend));
     }
@@ -409,7 +412,7 @@ TEST_CASE("Arithmetic result does not alias the source view", "[TensorView][Arit
 
         Tensor sum = A[0] + B[0]; // should be 3.0
 
-        // Mutate A — sum must stay 3.0
+        // Mutate A - sum must stay 3.0
         A = Tensor({2, 4}, 99.0f, backend);
 
         for (size_t j = 0; j < 4; j++) {

--- a/tests/test_view_arithemtic.cpp
+++ b/tests/test_view_arithemtic.cpp
@@ -26,8 +26,6 @@ TEST_CASE("TensorView copy produces an independent Tensor", "[TensorView][Copy]"
     DYNAMIC_SECTION(getBackendString(backend)) {
         Tensor src({3, 4}, 7.0f, backend);
 
-        std::cout << "src:\n";
-        src.print();
         auto   view = src[1];              // view of row-1 (4 elements)
         Tensor copy = view.copy();
 


### PR DESCRIPTION
Solves #4 

## Changes
 1. Added `Tensor` and `Tensor::View` arithmetic operations.
 2. Added `Tensor::View` and `Tensor` arithmetic operations.
 3. Added `Tensor::View` and `Tensor::View` arithmetic operations.
 4. Added `Tensor::View::copy`, returns the referenced part of the tensor as a new tensor. 
 
## Note 
One test is failing due to operations between scalars and tensors not being commutative. This would be solved in #6.