### PR TITLE
docs: add docs to benchmarks 

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -6,12 +6,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  BUILD_TYPE: Release
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      BUILD_TYPE: Debug 
     permissions:
       checks: write
       contents: read
@@ -74,6 +73,8 @@ jobs:
 
   benchmark:
     needs: build-and-test  # won't run if tests fail
+    env:
+      BUILD_TYPE: Release 
     runs-on: ubuntu-latest
     permissions:
       contents: write  # needed to push results to gh-pages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(NFORGE_ENABLE_CUDA "Enable CUDA support" OFF)
 option(NFORGE_BUILD_BENCHMARKS "Build benchmarks" ON)
 
+
 # Sources
 set(NFORGE_SRC
     src/core/tensor.cpp
@@ -38,6 +39,25 @@ target_include_directories(NForge
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
+
+## Release vs Debug build
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_options(NForge PRIVATE
+        -O3 -march=native -ffast-math -funroll-loops -fomit-frame-pointer
+    )
+    set_property(TARGET NForge PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+
+elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(NForge PRIVATE
+        -O0 -g -fsanitize=address -fsanitize=undefined
+    )
+    target_link_options(NForge PRIVATE
+        -fsanitize=address -fsanitize=undefined
+    )
+else()
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type" FORCE)
+    message(STATUS "No build type specified, defaulting to Debug")
+endif()
 
 if(NFORGE_ENABLE_CUDA)
     target_link_libraries(NForge PUBLIC CUDA::cudart CUDA::curand)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,20 +43,30 @@ target_include_directories(NForge
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+
 ## Add flags for Debug or Release
 target_compile_options(NForge PRIVATE
     # Release, non-MSVC
     $<$<AND:$<CONFIG:Release>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
-        -march=native -ffast-math -funroll-loops>
+        -march=native;-ffast-math;-funroll-loops>
 
     # Release, MSVC
     $<$<AND:$<CONFIG:Release>,$<CXX_COMPILER_ID:MSVC>>:
-        /arch:AVX2 /fp:fast>
-    
+        /arch:AVX2;/fp:fast>
+)
+
+target_compile_options(NForge PUBLIC
     # Debug, non-MSVC
     $<$<AND:$<CONFIG:Debug>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
-        -fsanitize=address -fsanitize=undefined>
+        -fsanitize=address;-fsanitize=undefined>
 )
+
+target_link_options(NForge PUBLIC
+    # Debug, non-MSVC
+    $<$<AND:$<CONFIG:Debug>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
+        -fsanitize=address;-fsanitize=undefined>
+)
+
 
 ## Configure CUDA dependencies
 if(NFORGE_ENABLE_CUDA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(NFORGE_ENABLE_CUDA "Enable CUDA support" OFF)
 option(NFORGE_BUILD_BENCHMARKS "Build benchmarks" ON)
 
 
-# Sources
+## Sources
 set(NFORGE_SRC
     src/core/tensor.cpp
     src/core/tensor_view.cpp
@@ -18,6 +18,7 @@ set(NFORGE_SRC
     src/ops/semantic/semantic.cpp
 )
 
+## Add CUDA sources
 if(NFORGE_ENABLE_CUDA)
     enable_language(CUDA)
 
@@ -33,12 +34,15 @@ endif()
 
 add_library(NForge STATIC ${NFORGE_SRC})
 
+
+## Includes
 target_include_directories(NForge
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
+
 
 ## Release vs Debug build
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
@@ -59,6 +63,8 @@ else()
     message(STATUS "No build type specified, defaulting to Debug")
 endif()
 
+
+## Configure CUDA dependencies
 if(NFORGE_ENABLE_CUDA)
     target_link_libraries(NForge PUBLIC CUDA::cudart CUDA::curand)
     
@@ -70,10 +76,13 @@ if(NFORGE_ENABLE_CUDA)
     set_property(TARGET NForge PROPERTY CUDA_ARCHITECTURES native)
 endif()
 
+
+## Testing
 enable_testing()
 add_subdirectory(tests)
 
 
+## Benchmarks
 if(NFORGE_BUILD_BENCHMARKS)
     add_subdirectory(benchmarks)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,26 +43,20 @@ target_include_directories(NForge
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
+## Add flags for Debug or Release
+target_compile_options(NForge PRIVATE
+    # Release, non-MSVC
+    $<$<AND:$<CONFIG:Release>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
+        -march=native -ffast-math -funroll-loops>
 
-## Release vs Debug build
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    target_compile_options(NForge PRIVATE
-        -O3 -march=native -ffast-math -funroll-loops -fomit-frame-pointer
-    )
-    set_property(TARGET NForge PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-
-elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_compile_options(NForge PRIVATE
-        -O0 -g -fsanitize=address -fsanitize=undefined
-    )
-    target_link_options(NForge PRIVATE
-        -fsanitize=address -fsanitize=undefined
-    )
-else()
-    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type" FORCE)
-    message(STATUS "No build type specified, defaulting to Debug")
-endif()
-
+    # Release, MSVC
+    $<$<AND:$<CONFIG:Release>,$<CXX_COMPILER_ID:MSVC>>:
+        /arch:AVX2 /fp:fast>
+    
+    # Debug, non-MSVC
+    $<$<AND:$<CONFIG:Debug>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
+        -fsanitize=address -fsanitize=undefined>
+)
 
 ## Configure CUDA dependencies
 if(NFORGE_ENABLE_CUDA)

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ cmake --build .
 
 Requires the CUDA Toolkit. MSBuild is recommended on Windows.
 
+
+| Build Option | Description | Default Value |
+|---|---|---|
+| `NFORGE_ENABLE_CUDA` | Toggels build CUDA backend | `OFF` |
+| `NFORGE_BUILD_BENCHMARKS` | Toggles build benchmarks | `ON` |
+
+
 ## Quick start
 
 ```cpp
@@ -137,7 +144,7 @@ a = b = c;   // both a and b now equal c
 
 #### Strided views
 
-`subsample(strides)` returns a view that steps through the tensor with the given per-dimension stride. The view shares the original tensor's memory, so assigning through it writes back directly — no copy needed.
+`subsample(strides)` returns a view that steps through the tensor with the given per-dimension stride. The view shares the original tensor's memory, so assigning through it writes back directly.
 
 ```cpp
 Tensor a({6}, 0.0f);
@@ -185,10 +192,19 @@ Run after building:
 ctest --progress
 ```
 
+## Benchmarks
+
+Benchmarks are ran on merge with `main` branch, if all tests passes. 
+
+Current benchmarks are the examples from physics scenarios with default parameters.
+The results are published to [marbjo07.github.io/NForge/dev/bench/](https://marbjo07.github.io/NForge/dev/bench/)  
+
 ## Roadmap
 
-- [ ] Float comparison with configurable epsilon (`approxEqual`) — #14
-- [ ] Frobenius norm — #15
-- [ ] Matrix multiplication — #16
-- [ ] Scalar/float–tensor comparison operators — #18  
-- [ ] Reduction operators (sum, mean, max, …) — #19
+- [ ] Float comparison with configurable epsilon (`approxEqual`) - #14
+- [ ] Frobenius norm - #15
+- [ ] Matrix multiplication - #16
+- [ ] Scalar/float–tensor comparison operators - #18  
+- [x] Reduction operators (sum, mean, max, …) - #19
+
+

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requires the CUDA Toolkit. MSBuild is recommended on Windows.
 
 | Build Option | Description | Default Value |
 |---|---|---|
-| `NFORGE_ENABLE_CUDA` | Toggels build CUDA backend | `OFF` |
+| `NFORGE_ENABLE_CUDA` | Toggles build CUDA backend | `OFF` |
 | `NFORGE_BUILD_BENCHMARKS` | Toggles build benchmarks | `ON` |
 
 
@@ -194,7 +194,7 @@ ctest --progress
 
 ## Benchmarks
 
-Benchmarks are ran on merge with `main` branch, if all tests passes. 
+Benchmarks run on merge with `main` branch, after all tests pass. 
 
 Current benchmarks are the examples from physics scenarios with default parameters.
 The results are published to [marbjo07.github.io/NForge/dev/bench/](https://marbjo07.github.io/NForge/dev/bench/)  
@@ -204,7 +204,7 @@ The results are published to [marbjo07.github.io/NForge/dev/bench/](https://marb
 - [ ] Float comparison with configurable epsilon (`approxEqual`) - #14
 - [ ] Frobenius norm - #15
 - [ ] Matrix multiplication - #16
-- [ ] Scalar/float–tensor comparison operators - #18  
+- [ ] Scalar/float–tensor comparison operators - #18
 - [x] Reduction operators (sum, mean, max, …) - #19
 
 


### PR DESCRIPTION
## Summary

- Compile options for Release and Debug
- Documented flags for CMake configure, enable cuda, benchmarks, etc.
- Introduced Benchmarks section with testing prerequisites, example scenarios, and publication link
- CI updated to set build type per job so benchmarks run in Release while regular builds use Debug
