### PR TITLE
docs: TensorLayout doxygen documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1026,7 +1026,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src include scenarios
+INPUT                  = src include README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that Doxygen parses. Internally Doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1524,7 +1524,7 @@ HTML_COLORSTYLE        = AUTO_LIGHT
 # Minimum value: 0, maximum value: 359, default value: 220.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_HUE    = 120
 
 # The HTML_COLORSTYLE_SAT tag controls the purity (or saturation) of the colors
 # in the HTML output. For a value of 0 the output will use gray-scales only. A
@@ -1532,7 +1532,7 @@ HTML_COLORSTYLE_HUE    = 220
 # Minimum value: 0, maximum value: 255, default value: 100.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_SAT    = 60
 
 # The HTML_COLORSTYLE_GAMMA tag controls the gamma correction applied to the
 # luminance component of the colors in the HTML output. Values below 100
@@ -1543,7 +1543,7 @@ HTML_COLORSTYLE_SAT    = 100
 # Minimum value: 40, maximum value: 240, default value: 80.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE_GAMMA  = 80
+HTML_COLORSTYLE_GAMMA  = 150
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that

--- a/Doxyfile
+++ b/Doxyfile
@@ -1026,7 +1026,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = 
+INPUT                  = src include scenarios
 
 # This tag can be used to specify the character encoding of the source files
 # that Doxygen parses. Internally Doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1130,7 +1130,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which Doxygen is
 # run.
 
-EXCLUDE                = build
+EXCLUDE                = 
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/Doxyfile
+++ b/Doxyfile
@@ -1524,7 +1524,7 @@ HTML_COLORSTYLE        = AUTO_LIGHT
 # Minimum value: 0, maximum value: 359, default value: 220.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE_HUE    = 180
+HTML_COLORSTYLE_HUE    = 220
 
 # The HTML_COLORSTYLE_SAT tag controls the purity (or saturation) of the colors
 # in the HTML output. For a value of 0 the output will use gray-scales only. A
@@ -1532,7 +1532,7 @@ HTML_COLORSTYLE_HUE    = 180
 # Minimum value: 0, maximum value: 255, default value: 100.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE_SAT    = 20
+HTML_COLORSTYLE_SAT    = 70
 
 # The HTML_COLORSTYLE_GAMMA tag controls the gamma correction applied to the
 # luminance component of the colors in the HTML output. Values below 100

--- a/Doxyfile
+++ b/Doxyfile
@@ -1241,7 +1241,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the Doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 # If the IMPLICIT_DIR_DOCS tag is set to YES, any README.md file found in sub-
 # directories of the project's root, is used as the documentation for that sub-
@@ -1524,7 +1524,7 @@ HTML_COLORSTYLE        = AUTO_LIGHT
 # Minimum value: 0, maximum value: 359, default value: 220.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE_HUE    = 120
+HTML_COLORSTYLE_HUE    = 180
 
 # The HTML_COLORSTYLE_SAT tag controls the purity (or saturation) of the colors
 # in the HTML output. For a value of 0 the output will use gray-scales only. A
@@ -1532,7 +1532,7 @@ HTML_COLORSTYLE_HUE    = 120
 # Minimum value: 0, maximum value: 255, default value: 100.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE_SAT    = 60
+HTML_COLORSTYLE_SAT    = 20
 
 # The HTML_COLORSTYLE_GAMMA tag controls the gamma correction applied to the
 # luminance component of the colors in the HTML output. Values below 100
@@ -1543,7 +1543,7 @@ HTML_COLORSTYLE_SAT    = 60
 # Minimum value: 40, maximum value: 240, default value: 80.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_COLORSTYLE_GAMMA  = 150
+HTML_COLORSTYLE_GAMMA  = 80
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # NForge
 
+[![Build](https://github.com/Marbjo07/NForge/actions/workflows/ci.yml/badge.svg)](https://github.com/Marbjo07/NForge/actions)
+[![Docs](https://img.shields.io/badge/docs-github%20pages-blue)](https://marbjo07.github.io/NForge/docs/html/index.html)
+[![Benchmarks](https://img.shields.io/badge/benchmarks-live-green)](https://marbjo07.github.io/NForge/dev/bench/)
+[![C++](https://img.shields.io/badge/C%2B%2B-17-blue?logo=cplusplus)](https://en.cppreference.com)
+
 A C++ tensor library with a focus on simplicity and ease of use, with optional CUDA support.
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Requires the CUDA Toolkit. MSBuild is recommended on Windows.
 
 ## Quick start
 
+### Code example
 ```cpp
 #include <iostream>
 #include "nforge/tensor.h"
@@ -51,7 +52,7 @@ int main() {
     a.print();
 }
 ```
-### Output:
+### Output
 
 ```text
 ====================
@@ -71,7 +72,7 @@ Documentation is built using Doxygen and Github Actions, then hosted on Github P
 See [marbjo07.github.io/NForge/docs](https://marbjo07.github.io/NForge/docs/html/index.html)
 
 To generate documentation locally, ensure Doxygen is installed, then from project root:
-``` bash
+```bash
 doxygen Doxyfile
 ```
 
@@ -212,17 +213,7 @@ ctest --progress
 
 ## Benchmarks
 
-Benchmarks run on merge with `main` branch, after all tests pass. 
+Benchmarks run on merge with `main` branch, after all tests pass.
 
 Current benchmarks are the examples from physics scenarios with default parameters.
 The results are published to [marbjo07.github.io/NForge/dev/bench/](https://marbjo07.github.io/NForge/dev/bench/)  
-
-## Roadmap
-
-- [ ] Float comparison with configurable epsilon (`approxEqual`) - #14
-- [x] Frobenius norm - #15
-- [ ] Matrix multiplication - #16
-- [ ] Scalar/float–tensor comparison operators - #18
-- [x] Reduction operators (sum, mean, max, …) - #19
-
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Build](https://github.com/Marbjo07/NForge/actions/workflows/ci.yml/badge.svg)](https://github.com/Marbjo07/NForge/actions)
 [![Docs](https://img.shields.io/badge/docs-github%20pages-blue)](https://marbjo07.github.io/NForge/docs/html/index.html)
 [![Benchmarks](https://img.shields.io/badge/benchmarks-live-green)](https://marbjo07.github.io/NForge/dev/bench/)
-[![C++](https://img.shields.io/badge/C%2B%2B-17-blue?logo=cplusplus)](https://en.cppreference.com)
+
+
 
 A C++ tensor library with a focus on simplicity and ease of use, with optional CUDA support.
 

--- a/include/nforge/core/tensor_layout.h
+++ b/include/nforge/core/tensor_layout.h
@@ -106,6 +106,9 @@ struct TensorLayout {
     /**
      * @brief Constructs a tensor layout from raw storage.
      * 
+     * @pre `_rank <= MAX_DIMS`
+     * @post `offset == _offset`
+     * 
      * @param shape Shape values.
      * @param strides Stride values.
      * @param offset Storage offset.
@@ -113,8 +116,7 @@ struct TensorLayout {
      */
     TensorLayout(std::array<size_t, MAX_DIMS> _shape,
                  std::array<size_t, MAX_DIMS> _strides,
-                 size_t _offset, size_t _rank)
-        : shape(_shape), strides(_strides), offset(_offset), rank(_rank) {}
+                 size_t _offset, size_t _rank);
 
     /**
      * @brief Checks whether two tensor layouts are equal.

--- a/include/nforge/core/tensor_layout.h
+++ b/include/nforge/core/tensor_layout.h
@@ -8,24 +8,139 @@
 
 #define MAX_DIMS 8
 
+/**
+ * @class TensorLayout
+ * @brief Describes the memory layout of a tensor.
+ *
+ * A tensor layout stores:
+ * - the tensor shape,
+ * - the stride for each dimension,
+ * - an optional storage offset,
+ * - the number of active dimensions (`rank`).
+ *
+ * @invariant `0 <= rank && rank <= MAX_DIMS`
+ * @invariant Elements in `shape` and `strides` are only meaningful for the first `rank` active entries
+ */
 struct TensorLayout {
+
+    /**
+     * @brief Shape of the tensor.
+     *
+     * The shape values describe the extent of each dimension.
+     *
+     * @note Only the entries corresponding to the active rank are meaningful.
+     */
     std::array<size_t, MAX_DIMS> shape;
+
+    /**
+     * @brief Strides for each tensor dimension.
+     *
+     * A stride describes how many elements must be skipped to move to the next index
+     * along a given dimension.
+     *
+     * @note Only the entries corresponding to the active rank are meaningful.
+     */
     std::array<size_t, MAX_DIMS> strides;
+
+    /**
+     * @brief Number of elements skipped before indexing starts.
+     */
     size_t offset = 0;
+
+    /**
+     * @brief Number of active dimensions in the layout.
+     *
+     * Only the first `rank` entries of `shape` and `strides` are considered valid.
+     */
     size_t rank = 0;
-    
+
+    /**
+     * @brief Constructs an empty tensor layout.
+     *
+     * @post `rank == 0`
+     * @post `offset == 0`
+     */
     TensorLayout() : shape{}, strides{} {}
+
+    /**
+     * @brief Constructs a contiguous tensor layout from a shape.
+     *
+     * The layout receives contiguous strides inferred from `_shape`.
+     *
+     * @pre `_shape.getNumDims() <= MAX_DIMS`
+     * @post `rank == _shape.getNumDims()`
+     * @post `offset == 0`
+     * @post `strides` contains contiguous strides for `_shape`
+     *
+     * @param _shape Shape of the tensor layout.
+     */
     TensorLayout(const Tensor::Shape& _shape);
+
+    /**
+     * @brief Constructs a tensor layout from a shape and explicit strides.
+     *
+     * @pre `_shape.getNumDims() <= MAX_DIMS`
+     * @pre `_strides.size() == _shape.getNumDims()`
+     * @post `rank == _shape.getNumDims()`
+     * @post `offset == 0`
+     *
+     * @param _shape Shape of the tensor layout.
+     * @param _strides Explicit strides for each dimension.
+     */
     TensorLayout(const Tensor::Shape& _shape, const std::vector<size_t>& _strides);
+
+    /**
+     * @brief Constructs a tensor layout from a shape, explicit strides, and offset.
+     *
+     * @pre `_shape.getNumDims() <= MAX_DIMS`
+     * @pre `_strides.size() == _shape.getNumDims()`
+     * @post `rank == _shape.getNumDims()`
+     * @post `offset == _offset`
+     *
+     * @param _shape Shape of the tensor layout.
+     * @param _strides Explicit strides for each dimension.
+     * @param _offset Storage offset before indexing begins.
+     */
     TensorLayout(const Tensor::Shape& _shape, const std::vector<size_t>& _strides, size_t _offset);
 
-    TensorLayout(std::array<size_t, MAX_DIMS> shape, 
-                 std::array<size_t, MAX_DIMS> strides,
-                 size_t offset, size_t rank)
-        : shape(shape), strides(strides), offset(offset), rank(rank) {}
+    /**
+     * @brief Constructs a tensor layout from raw storage.
+     * 
+     * @param shape Shape values.
+     * @param strides Stride values.
+     * @param offset Storage offset.
+     * @param rank Number of active dimensions.
+     */
+    TensorLayout(std::array<size_t, MAX_DIMS> _shape,
+                 std::array<size_t, MAX_DIMS> _strides,
+                 size_t _offset, size_t _rank)
+        : shape(_shape), strides(_strides), offset(_offset), rank(_rank) {}
 
-    bool operator==(const TensorLayout& lhs) const;
-    bool operator!=(const TensorLayout& lhs) const;
+    /**
+     * @brief Checks whether two tensor layouts are equal.
+     *
+     * Two layouts are equal if they have the same:
+     * - rank
+     * - offset
+     * - active shape values
+     * - active stride values
+     *
+     * Only the active `rank` entries are compared.
+     *
+     * @param rhs The layout to compare against.
+     * @return `true` if the layouts are equal, otherwise `false`.
+     */
+    bool operator==(const TensorLayout& rhs) const;
+
+    /**
+     * @brief Checks whether two tensor layouts are not equal.
+     *
+     * Equivalent to `!(*this == rhs)`.
+     *
+     * @param rhs The layout to compare against.
+     * @return `true` if the layouts are not equal, otherwise `false`.
+     */
+    bool operator!=(const TensorLayout& rhs) const;
 };
 
 

--- a/include/nforge/core/tensor_layout.h
+++ b/include/nforge/core/tensor_layout.h
@@ -146,7 +146,15 @@ struct TensorLayout {
 };
 
 
-
+/**
+ * @brief Converts a linear index to a physical offset in memory based on the given tensor layout.
+ * 
+ * Accounts for the shape, strides, and offset defined in the layout to compute the correct element offset.
+ * 
+ * @param linear Linear index. This is the index as if the tensor were stored contiguously in memory.
+ * @param L Tensor layout describing the arrangement of the tensor.
+ * @return Element offset corresponding to the linear index in the layout.
+ */
 static inline size_t physicalOffset(size_t linear, const TensorLayout& L) {
     size_t off = L.offset;
     for (int d = L.rank - 1; d >= 0; d--) {

--- a/src/core/tensor_layout.cpp
+++ b/src/core/tensor_layout.cpp
@@ -33,6 +33,11 @@ TensorLayout::TensorLayout(const Tensor::Shape& _shape, const std::vector<size_t
     std::copy(_strides.begin(), _strides.end(), strides.begin());
 }
 
+TensorLayout::TensorLayout(std::array<size_t, MAX_DIMS> _shape, std::array<size_t, MAX_DIMS> _strides, size_t _offset, size_t _rank) 
+    : shape(_shape), strides(_strides), offset(_offset), rank(_rank) {
+    assert(_rank <= MAX_DIMS);
+}
+
 bool TensorLayout::operator==(const TensorLayout& rhs) const {
     if (rank != rhs.rank) return false;
     if (offset != rhs.offset) return false;

--- a/tests/unit/test_arithmetic.cpp
+++ b/tests/unit/test_arithmetic.cpp
@@ -49,8 +49,8 @@ TEST_CASE("Scalar broadcasting works on all backends", "[Tensor][Arithmetic]") {
 TEST_CASE("2D arithmetic consistency across backends", "[Tensor][Arithmetic]") {
     auto backend = GENERATE(from_range(backends));
 
-    auto rows = GENERATE(1ull, 3ull, 7ull);
-    auto cols = GENERATE(1ull, 5ull, 11ull);
+    auto rows = GENERATE(1ul, 3ul, 7ul);
+    auto cols = GENERATE(1ul, 5ul, 11ul);
 
     DYNAMIC_SECTION(
         "Backend=" << getBackendString(backend)

--- a/tests/unit/test_tensor.cpp
+++ b/tests/unit/test_tensor.cpp
@@ -155,8 +155,8 @@ TEST_CASE("2D tensor shape and indexing", "[Tensor]") {
     auto backend = GENERATE(from_range(backends));
 
     DYNAMIC_SECTION(getBackendString(backend)) {
-        auto rows = GENERATE(1ull, 4ull, 10ull);
-        auto cols = GENERATE(1ull, 10ull, 50ull);
+        auto rows = GENERATE(1ul, 4ul, 10ul);
+        auto cols = GENERATE(1ul, 10ul, 50ul);
         auto val = GENERATE(-1001.0f, 0.32f, 122.9f);
 
         DYNAMIC_SECTION("rows=" << rows << " cols=" << cols << " val=" << val) {
@@ -200,8 +200,8 @@ TEST_CASE("Tensor view assign", "[Tensor]") {
     auto backend = GENERATE(from_range(backends));
 
     DYNAMIC_SECTION(getBackendString(backend)) {
-        auto rows = GENERATE(1ull, 2ull, 3ull);
-        auto cols = GENERATE(1ull, 4ull, 8ull);
+        auto rows = GENERATE(1ul, 2ul, 3ul);
+        auto cols = GENERATE(1ul, 4ul, 8ul);
         auto val = GENERATE(0.0f, 1.5f);
 
         DYNAMIC_SECTION("rows=" << rows << " cols=" << cols << " val=" << val) {

--- a/tests/unit/test_view_arithemtic.cpp
+++ b/tests/unit/test_view_arithemtic.cpp
@@ -292,8 +292,8 @@ TEST_CASE("View * scalar Tensor", "[Tensor][View][Arithmetic]") {
 TEST_CASE("2D View arithmetic consistency across backends", "[View][Arithmetic]") {
     auto backend = GENERATE(from_range(backends));
 
-    auto rows = GENERATE(2ull, 4ull, 8ull);
-    auto cols = GENERATE(1ull, 5ull, 11ull);
+    auto rows = GENERATE(2ul, 4ul, 8ul);
+    auto cols = GENERATE(1ul, 5ul, 11ul);
 
     DYNAMIC_SECTION(
         "Backend=" << getBackendString(backend)
@@ -322,8 +322,8 @@ TEST_CASE("2D View arithmetic consistency across backends", "[View][Arithmetic]"
 TEST_CASE("Mixed Tensor/View 2D parametric test", "[Tensor][View][Arithmetic]") {
     auto backend = GENERATE(from_range(backends));
 
-    auto rows = GENERATE(1ull, 3ull, 7ull);
-    auto cols = GENERATE(1ull, 5ull, 11ull);
+    auto rows = GENERATE(1ul, 3ul, 7ul);
+    auto cols = GENERATE(1ul, 5ul, 11ul);
 
     DYNAMIC_SECTION(
         "Backend=" << getBackendString(backend)

--- a/tests/unit/test_view_stride.cpp
+++ b/tests/unit/test_view_stride.cpp
@@ -308,7 +308,7 @@ TEST_CASE("Broadcast view * normal tensor", "[View][Stride][Arithmetic]") {
 TEST_CASE("Stride of 1 gives same shape as original", "[View][Stride]") {
     auto backend = GENERATE(from_range(backends));
 
-    auto size = GENERATE(1ull, 4ull, 13ull);
+    auto size = GENERATE(1ul, 4ul, 13ul);
 
     DYNAMIC_SECTION(getBackendString(backend) << " size=" << size) {
         Tensor a({size}, 2.0f, backend);
@@ -386,8 +386,8 @@ TEST_CASE("Assign to zero-strided view multiple times", "[View][Stride]") {
 TEST_CASE("Parametric 1D stride consistency", "[View][Stride]") {
     auto backend = GENERATE(from_range(backends));
 
-    auto total = GENERATE(6ull, 12ull, 24ull);
-    auto stride = GENERATE(1ull, 2ull, 3ull);
+    auto total = GENERATE(6ul, 12ul, 24ul);
+    auto stride = GENERATE(1ul, 2ul, 3ul);
 
     DYNAMIC_SECTION(
         "Backend=" << getBackendString(backend)


### PR DESCRIPTION
## Summary

- Add doxygen documentation for TensorLayout struct
- Add badges to README.md, CI status, benchmarks, docs and c++ version.
- Resolve narrowing conversion error in tests.