### PR TITLE
feat: implement scalar assignment for float (closes #20)

### DIFF
--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -100,6 +100,7 @@ class Tensor {
     Tensor::View subsample(std::vector<size_t> strides) const;
 
     Tensor& operator=(const Tensor& rhs);
+    Tensor& operator=(float scalar);
 
     bool operator==(const Tensor::View& rhs) const;
     bool operator!=(const Tensor::View& rhs) const;

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -254,6 +254,16 @@ Tensor& Tensor::operator=(const Tensor& rhs) {
     return *this;
 }
 
+Tensor& Tensor::operator=(float scalar) {
+    if (!this->getShape().isScalar()) {
+        throw std::runtime_error("Cannot assign float to a non-scalar tensor.");
+    }
+
+    *this = Tensor(this->getShape(), scalar, this->m_backend);
+
+    return *this;
+}
+
 bool Tensor::operator==(const Tensor::View& rhs) const {
     return compare(rhs);
 }


### PR DESCRIPTION
This PR implements the overloaded assignment operator for scalar tensors, as requested in issue #20.

Changes:
- Added Tensor& operator=(float scalar) to Tensor class.
- Included validation to ensure the tensor is scalar before assignment, throwing std::runtime_error otherwise.
- Verified implementation using the test cases provided in this branch.

Closes #20