### PR TITLE
chore: cuda backend sync (closes #47)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /docs/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,23 +47,23 @@ target_include_directories(NForge
 ## Add flags for Debug or Release
 target_compile_options(NForge PRIVATE
     # Release, non-MSVC
-    $<$<AND:$<CONFIG:Release>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
+    $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
         -march=native;-ffast-math;-funroll-loops>
 
     # Release, MSVC
-    $<$<AND:$<CONFIG:Release>,$<CXX_COMPILER_ID:MSVC>>:
+    $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:
         /arch:AVX2;/fp:fast>
 )
 
 target_compile_options(NForge PUBLIC
     # Debug, non-MSVC
-    $<$<AND:$<CONFIG:Debug>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
+    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
         -fsanitize=address;-fsanitize=undefined>
 )
 
 target_link_options(NForge PUBLIC
     # Debug, non-MSVC
-    $<$<AND:$<CONFIG:Debug>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
+    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
         -fsanitize=address;-fsanitize=undefined>
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,39 +44,15 @@ target_include_directories(NForge
 )
 
 
-## Add flags for Debug or Release
-target_compile_options(NForge PRIVATE
-    # Release, non-MSVC
-    $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
-        -march=native;-ffast-math;-funroll-loops>
-
-    # Release, MSVC
-    $<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:
-        /arch:AVX2;/fp:fast>
-)
-
-target_compile_options(NForge PUBLIC
-    # Debug, non-MSVC
-    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
-        -fsanitize=address;-fsanitize=undefined>
-)
-
-target_link_options(NForge PUBLIC
-    # Debug, non-MSVC
-    $<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:
-        -fsanitize=address;-fsanitize=undefined>
-)
+## Compiler flags for configs
+include(cmake/CompilerFlags.cmake)
+nforge_apply_compiler_flags(NForge)
 
 
 ## Configure CUDA dependencies
 if(NFORGE_ENABLE_CUDA)
     target_link_libraries(NForge PUBLIC CUDA::cudart CUDA::curand)
     
-   
-    target_compile_options(NForge PRIVATE 
-        $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>  # allow constexpr host functions in device functions
-    )
-
     set_property(TARGET NForge PROPERTY CUDA_ARCHITECTURES native)
 endif()
 

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -1,0 +1,50 @@
+# Helpers to add a CXX flag guarded by compiler, config, and language
+function(nforge_cxx_flag target visibility config flag)
+    target_compile_options(${target} ${visibility}
+        $<$<AND:$<CONFIG:${config}>,$<COMPILE_LANGUAGE:CXX>>:${flag}>)
+endfunction()
+
+function(nforge_cuda_flag target visibility config flag)
+    target_compile_options(${target} ${visibility}
+        $<$<AND:$<CONFIG:${config}>,$<COMPILE_LANGUAGE:CUDA>>:${flag}>)
+endfunction()
+
+function(nforge_link_flag target visibility config flag)
+    target_link_options(${target} ${visibility}
+        $<$<CONFIG:${config}>:${flag}>)
+endfunction()
+
+
+function(nforge_apply_compiler_flags target)
+    ## Release: CXX 
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        nforge_cxx_flag(${target} PRIVATE Release -march=native)
+        nforge_cxx_flag(${target} PRIVATE Release -ffast-math)
+        nforge_cxx_flag(${target} PRIVATE Release -funroll-loops)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        nforge_cxx_flag(${target} PRIVATE Release /arch:AVX2)
+        nforge_cxx_flag(${target} PRIVATE Release /fp:fast)
+    else()
+        message(WARNING "NForge: unrecognised CXX compiler '${CMAKE_CXX_COMPILER_ID}', no release flags set")
+    endif()
+
+    ## Debug: CXX and linker
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        nforge_cxx_flag (${target} PUBLIC Debug -fsanitize=address)
+        nforge_cxx_flag (${target} PUBLIC Debug -fsanitize=undefined)
+        nforge_link_flag(${target} PUBLIC Debug -fsanitize=address)
+        nforge_link_flag(${target} PUBLIC Debug -fsanitize=undefined)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        nforge_cxx_flag(${target} PUBLIC Debug /fsanitize=address)
+    endif()
+
+    ## CUDA 
+    if(NFORGE_ENABLE_CUDA)
+        nforge_cuda_flag(${target} PRIVATE Release --use_fast_math)
+        nforge_cuda_flag(${target} PRIVATE Debug   -G)
+
+        # allow constexpr host functions in device functions
+        nforge_cuda_flag(${target} PRIVATE Release --expt-relaxed-constexpr)
+        nforge_cuda_flag(${target} PRIVATE Debug --expt-relaxed-constexpr)
+    endif()
+endfunction()

--- a/include/nforge/core/tensor_view.h
+++ b/include/nforge/core/tensor_view.h
@@ -51,6 +51,8 @@ class Tensor::View {
 
     Tensor::View operator=(const Tensor& rhs);
     Tensor::View operator=(const Tensor::View& rhs);
+    Tensor::View operator=(float scalar);
+    
     Tensor::View operator[](size_t idx) const;
 
     Tensor::View subsample(std::vector<size_t> strides) const;

--- a/src/backend/cuda/kernels/kernels.cu
+++ b/src/backend/cuda/kernels/kernels.cu
@@ -153,3 +153,20 @@ __global__ void idivKernel(float* __restrict__ lhs, const TensorLayout lhsLayout
     size_t rhsIdx = physicalOffsetCUDA(i, rhsLayout);
     lhs[lhsIdx] /= rhs[rhsIdx];
 }
+
+__global__ void squareSumKernel(const float* __restrict__ data, float* result, size_t count) {
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    
+    if (i >= count) return;
+    float x = data[i] * data[i];
+
+    atomicAdd(result, x);
+}
+
+
+__global__ void isqrtKernel(float* __restrict__ data, size_t count) {
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    
+    if (i >= count) return;
+    data[i] = sqrt(data[i]);
+}

--- a/src/backend/cuda/kernels/kernels.cu
+++ b/src/backend/cuda/kernels/kernels.cu
@@ -105,3 +105,51 @@ __global__ void checkAllEqualKernel(
     size_t rhsIdx = physicalOffsetCUDA(i, rhsLayout);
     if (lhs[lhsIdx] != rhs[rhsIdx]) *isEqualFlag = 0;
 }
+
+__global__ void iaddKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
+    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
+
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (i >= count) return;
+
+    size_t lhsIdx = physicalOffsetCUDA(i, lhsLayout);
+    size_t rhsIdx = physicalOffsetCUDA(i, rhsLayout);
+    lhs[lhsIdx] += rhs[rhsIdx];
+}
+
+__global__ void isubKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
+    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
+
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (i >= count) return;
+
+    size_t lhsIdx = physicalOffsetCUDA(i, lhsLayout);
+    size_t rhsIdx = physicalOffsetCUDA(i, rhsLayout);
+    lhs[lhsIdx] -= rhs[rhsIdx];
+}
+
+__global__ void imulKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
+    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
+
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (i >= count) return;
+
+    size_t lhsIdx = physicalOffsetCUDA(i, lhsLayout);
+    size_t rhsIdx = physicalOffsetCUDA(i, rhsLayout);
+    lhs[lhsIdx] *= rhs[rhsIdx];
+}
+
+__global__ void idivKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
+    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
+
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (i >= count) return;
+
+    size_t lhsIdx = physicalOffsetCUDA(i, lhsLayout);
+    size_t rhsIdx = physicalOffsetCUDA(i, rhsLayout);
+    lhs[lhsIdx] /= rhs[rhsIdx];
+}

--- a/src/backend/cuda/kernels/kernels.cu
+++ b/src/backend/cuda/kernels/kernels.cu
@@ -195,7 +195,7 @@ __device__ static float atomicMul(float* address, float val) {
 }
 
 __global__ void sumReductionKernel(const float* __restrict__ data, float* result,
-                                   const TensorLayout layout, const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout layout, size_t blockCount,
                                    const TensorLayout outLayout, size_t outCount) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= blockCount * outCount) return;
@@ -207,7 +207,7 @@ __global__ void sumReductionKernel(const float* __restrict__ data, float* result
 }
 
 __global__ void minReductionKernel(const float* __restrict__ data, float* result,
-                                   const TensorLayout layout, const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout layout, size_t blockCount,
                                    const TensorLayout outLayout, size_t outCount) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= blockCount * outCount) return;
@@ -219,7 +219,7 @@ __global__ void minReductionKernel(const float* __restrict__ data, float* result
 }
 
 __global__ void maxReductionKernel(const float* __restrict__ data, float* result,
-                                   const TensorLayout layout, const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout layout, size_t blockCount,
                                    const TensorLayout outLayout, size_t outCount) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= blockCount * outCount) return;
@@ -232,7 +232,7 @@ __global__ void maxReductionKernel(const float* __restrict__ data, float* result
 
 
 __global__ void prodReductionKernel(const float* __restrict__ data, float* result,
-                                   const TensorLayout layout, const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout layout, size_t blockCount,
                                    const TensorLayout outLayout, size_t outCount) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= blockCount * outCount) return;

--- a/src/backend/cuda/kernels/kernels.cu
+++ b/src/backend/cuda/kernels/kernels.cu
@@ -11,10 +11,9 @@ __device__ __forceinline__ size_t physicalOffsetCUDA(size_t linear, const Tensor
 }
 
 __global__ void addKernel(
-    const float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, 
+    const float* __restrict__ lhs, const TensorLayout lhsLayout,
+    const float* __restrict__ rhs, const TensorLayout rhsLayout,
     float* __restrict__ out, const TensorLayout outLayout, size_t count) {
-
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (i >= count) return;
@@ -30,7 +29,6 @@ __global__ void subKernel(
     const float* __restrict__ lhs, const TensorLayout lhsLayout,
     const float* __restrict__ rhs, const TensorLayout rhsLayout,
     float* __restrict__ out, const TensorLayout outLayout, size_t count) {
-
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (i >= count) return;
@@ -46,7 +44,6 @@ __global__ void mulKernel(
     const float* __restrict__ lhs, const TensorLayout lhsLayout,
     const float* __restrict__ rhs, const TensorLayout rhsLayout,
     float* __restrict__ out, const TensorLayout outLayout, size_t count) {
-
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (i >= count) return;
@@ -62,7 +59,6 @@ __global__ void divKernel(
     const float* __restrict__ lhs, const TensorLayout lhsLayout,
     const float* __restrict__ rhs, const TensorLayout rhsLayout,
     float* __restrict__ out, const TensorLayout outLayout, size_t count) {
-
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (i >= count) return;
@@ -74,17 +70,14 @@ __global__ void divKernel(
     out[outIdx] = lhs[lhsIdx] / rhs[rhsIdx];
 }
 
-
 __global__ void fillKernel(float* __restrict__ data, float value, size_t count) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i < count) data[i] = value;
 }
 
-
 __global__ void setKernel(
     float* __restrict__ dst, const TensorLayout dstLayout,
     const float* __restrict__ src, const TensorLayout srcLayout, size_t count) {
-
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= count) return;
 
@@ -97,7 +90,6 @@ __global__ void checkAllEqualKernel(
     const float* __restrict__ lhs, const TensorLayout lhsLayout,
     const float* __restrict__ rhs, const TensorLayout rhsLayout,
     int* isEqualFlag, size_t count) {
-
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= count) return;
 
@@ -106,9 +98,8 @@ __global__ void checkAllEqualKernel(
     if (lhs[lhsIdx] != rhs[rhsIdx]) *isEqualFlag = 0;
 }
 
-__global__ void iaddKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
-
+__global__ void iaddKernel(float* __restrict__ lhs, const TensorLayout lhsLayout,
+                           const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (i >= count) return;
@@ -118,9 +109,8 @@ __global__ void iaddKernel(float* __restrict__ lhs, const TensorLayout lhsLayout
     lhs[lhsIdx] += rhs[rhsIdx];
 }
 
-__global__ void isubKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
-
+__global__ void isubKernel(float* __restrict__ lhs, const TensorLayout lhsLayout,
+                           const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (i >= count) return;
@@ -130,9 +120,8 @@ __global__ void isubKernel(float* __restrict__ lhs, const TensorLayout lhsLayout
     lhs[lhsIdx] -= rhs[rhsIdx];
 }
 
-__global__ void imulKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
-
+__global__ void imulKernel(float* __restrict__ lhs, const TensorLayout lhsLayout,
+                           const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (i >= count) return;
@@ -142,9 +131,8 @@ __global__ void imulKernel(float* __restrict__ lhs, const TensorLayout lhsLayout
     lhs[lhsIdx] *= rhs[rhsIdx];
 }
 
-__global__ void idivKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
-
+__global__ void idivKernel(float* __restrict__ lhs, const TensorLayout lhsLayout,
+                           const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
 
     if (i >= count) return;
@@ -154,19 +142,103 @@ __global__ void idivKernel(float* __restrict__ lhs, const TensorLayout lhsLayout
     lhs[lhsIdx] /= rhs[rhsIdx];
 }
 
+__global__ void isqrtKernel(float* __restrict__ data, size_t count) {
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (i >= count) return;
+    data[i] = sqrt(data[i]);
+}
+
 __global__ void squareSumKernel(const float* __restrict__ data, float* result, size_t count) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
-    
+
     if (i >= count) return;
     float x = data[i] * data[i];
 
     atomicAdd(result, x);
 }
 
+__device__ static float atomicMin(float* address, float val) {
+    int* address_as_i = (int*)address;
+    int old = *address_as_i, assumed;
+    do {
+        assumed = old;
+        // Use fminf to find the max of the current value and the new value
+        old = atomicCAS(address_as_i, assumed,
+                        __float_as_int(fminf(val, __int_as_float(assumed))));
+    } while (assumed != old);  // Repeat if another thread updated the memory
+    return __int_as_float(old);
+}
 
-__global__ void isqrtKernel(float* __restrict__ data, size_t count) {
+__device__ static float atomicMax(float* address, float val) {
+    int* address_as_i = (int*)address;
+    int old = *address_as_i, assumed;
+    do {
+        assumed = old;
+        // Use fmaxf to find the max of the current value and the new value
+        old = atomicCAS(address_as_i, assumed,
+                        __float_as_int(fmaxf(val, __int_as_float(assumed))));
+    } while (assumed != old);  // Repeat if another thread updated the memory
+    return __int_as_float(old);
+}
+
+__device__ static float atomicMul(float* address, float val) {
+    int* address_as_i = (int*)address;
+    int old = *address_as_i, assumed;
+    do {
+        assumed = old;
+        // Multiply the current value and the new value
+        old = atomicCAS(address_as_i, assumed,
+                        __float_as_int(val * __int_as_float(assumed)));
+    } while (assumed != old);  // Repeat if another thread updated the memory
+    return __int_as_float(old);
+}
+
+__global__ void sumReductionKernel(const float* __restrict__ data, float* result,
+                                   const TensorLayout layout, const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout outLayout, size_t outCount) {
     size_t i = blockIdx.x * blockDim.x + threadIdx.x;
-    
-    if (i >= count) return;
-    data[i] = sqrt(data[i]);
+    if (i >= blockCount * outCount) return;
+
+    size_t outIdx = physicalOffsetCUDA(i / blockCount, outLayout);
+    size_t dataIdx = physicalOffsetCUDA(i, layout);
+
+    atomicAdd(&result[outIdx], data[dataIdx]);
+}
+
+__global__ void minReductionKernel(const float* __restrict__ data, float* result,
+                                   const TensorLayout layout, const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout outLayout, size_t outCount) {
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= blockCount * outCount) return;
+
+    size_t outIdx = physicalOffsetCUDA(i / blockCount, outLayout);
+    size_t dataIdx = physicalOffsetCUDA(i, layout);
+
+    atomicMin(&result[outIdx], data[dataIdx]);
+}
+
+__global__ void maxReductionKernel(const float* __restrict__ data, float* result,
+                                   const TensorLayout layout, const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout outLayout, size_t outCount) {
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= blockCount * outCount) return;
+
+    size_t outIdx = physicalOffsetCUDA(i / blockCount, outLayout);
+    size_t dataIdx = physicalOffsetCUDA(i, layout);
+
+    atomicMax(&result[outIdx], data[dataIdx]);
+}
+
+
+__global__ void prodReductionKernel(const float* __restrict__ data, float* result,
+                                   const TensorLayout layout, const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout outLayout, size_t outCount) {
+    size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= blockCount * outCount) return;
+
+    size_t outIdx = physicalOffsetCUDA(i / blockCount, outLayout);
+    size_t dataIdx = physicalOffsetCUDA(i, layout);
+
+    atomicMul(&result[outIdx], data[dataIdx]);
 }

--- a/src/backend/cuda/kernels/kernels.cuh
+++ b/src/backend/cuda/kernels/kernels.cuh
@@ -2,6 +2,7 @@
 #define KERNELS_CUH
 
 #include "nforge/core/tensor_layout.h"
+#include "backend/cuda/utils/cuda_utils.h"
 
 __device__ __forceinline__ size_t physicalOffsetCUDA(size_t linear, const TensorLayout& L);
 

--- a/src/backend/cuda/kernels/kernels.cuh
+++ b/src/backend/cuda/kernels/kernels.cuh
@@ -5,26 +5,26 @@
 
 __device__ __forceinline__ size_t physicalOffsetCUDA(size_t linear, const TensorLayout& L);
 
+// binary operations
 __global__ void addKernel(
-    const float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, 
+    const float* __restrict__ lhs, const TensorLayout lhsLayout,
+    const float* __restrict__ rhs, const TensorLayout rhsLayout,
     float* __restrict__ out, const TensorLayout outLayout, size_t count);
 
 __global__ void subKernel(
-    const float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, 
+    const float* __restrict__ lhs, const TensorLayout lhsLayout,
+    const float* __restrict__ rhs, const TensorLayout rhsLayout,
     float* __restrict__ out, const TensorLayout outLayout, size_t count);
 
 __global__ void mulKernel(
-    const float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, 
+    const float* __restrict__ lhs, const TensorLayout lhsLayout,
+    const float* __restrict__ rhs, const TensorLayout rhsLayout,
     float* __restrict__ out, const TensorLayout outLayout, size_t count);
 
 __global__ void divKernel(
-    const float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, 
+    const float* __restrict__ lhs, const TensorLayout lhsLayout,
+    const float* __restrict__ rhs, const TensorLayout rhsLayout,
     float* __restrict__ out, const TensorLayout outLayout, size_t count);
-
 
 __global__ void fillKernel(float* __restrict__ data, float value, size_t count);
 
@@ -37,20 +37,38 @@ __global__ void checkAllEqualKernel(
     const float* __restrict__ rhs, const TensorLayout rhsLayout,
     int* isEqualFlag, size_t count);
 
-__global__ void iaddKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
+// in-place kernels
+__global__ void iaddKernel(float* __restrict__ lhs, const TensorLayout lhsLayout,
+                           const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
 
-__global__ void isubKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
+__global__ void isubKernel(float* __restrict__ lhs, const TensorLayout lhsLayout,
+                           const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
 
-__global__ void imulKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
-    
-__global__ void idivKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
-    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
+__global__ void imulKernel(float* __restrict__ lhs, const TensorLayout lhsLayout,
+                           const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
 
-__global__ void squareSumKernel(const float* __restrict__ data, float* result, size_t count);
+__global__ void idivKernel(float* __restrict__ lhs, const TensorLayout lhsLayout,
+                           const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
 
 __global__ void isqrtKernel(float* __restrict__ data, size_t count);
 
-#endif // KERNELS_CUH
+// reduction kernels
+__global__ void squareSumKernel(const float* __restrict__ data, float* result, size_t count);
+
+__global__ void sumReductionKernel(const float* __restrict__ data, float* result, const TensorLayout layout, 
+                                   const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout outLayout, size_t outCount);
+
+__global__ void minReductionKernel(const float* __restrict__ data, float* result, const TensorLayout layout, 
+                                   const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout outLayout, size_t outCount);
+
+__global__ void maxReductionKernel(const float* __restrict__ data, float* result, const TensorLayout layout, 
+                                   const TensorLayout blockLayout, size_t blockCount,
+                                   const TensorLayout outLayout, size_t outCount);
+
+__global__ void prodReductionKernel(const float* __restrict__ data, float* result, const TensorLayout layout, 
+                                    const TensorLayout blockLayout, size_t blockCount,
+                                    const TensorLayout outLayout, size_t outCount);
+
+#endif  // KERNELS_CUH

--- a/src/backend/cuda/kernels/kernels.cuh
+++ b/src/backend/cuda/kernels/kernels.cuh
@@ -55,20 +55,20 @@ __global__ void isqrtKernel(float* __restrict__ data, size_t count);
 // reduction kernels
 __global__ void squareSumKernel(const float* __restrict__ data, float* result, size_t count);
 
-__global__ void sumReductionKernel(const float* __restrict__ data, float* result, const TensorLayout layout, 
-                                   const TensorLayout blockLayout, size_t blockCount,
+__global__ void sumReductionKernel(const float* __restrict__ data, float* result, 
+                                   const TensorLayout layout, size_t blockCount,
                                    const TensorLayout outLayout, size_t outCount);
 
-__global__ void minReductionKernel(const float* __restrict__ data, float* result, const TensorLayout layout, 
-                                   const TensorLayout blockLayout, size_t blockCount,
+__global__ void minReductionKernel(const float* __restrict__ data, float* result, 
+                                   const TensorLayout layout, size_t blockCount,
                                    const TensorLayout outLayout, size_t outCount);
 
-__global__ void maxReductionKernel(const float* __restrict__ data, float* result, const TensorLayout layout, 
-                                   const TensorLayout blockLayout, size_t blockCount,
+__global__ void maxReductionKernel(const float* __restrict__ data, float* result, 
+                                   const TensorLayout layout, size_t blockCount,
                                    const TensorLayout outLayout, size_t outCount);
 
-__global__ void prodReductionKernel(const float* __restrict__ data, float* result, const TensorLayout layout, 
-                                    const TensorLayout blockLayout, size_t blockCount,
+__global__ void prodReductionKernel(const float* __restrict__ data, float* result, 
+                                    const TensorLayout layout, size_t blockCount,
                                     const TensorLayout outLayout, size_t outCount);
 
 #endif  // KERNELS_CUH

--- a/src/backend/cuda/kernels/kernels.cuh
+++ b/src/backend/cuda/kernels/kernels.cuh
@@ -49,4 +49,8 @@ __global__ void imulKernel(float* __restrict__ lhs, const TensorLayout lhsLayout
 __global__ void idivKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
     const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
 
+__global__ void squareSumKernel(const float* __restrict__ data, float* result, size_t count);
+
+__global__ void isqrtKernel(float* __restrict__ data, size_t count);
+
 #endif // KERNELS_CUH

--- a/src/backend/cuda/kernels/kernels.cuh
+++ b/src/backend/cuda/kernels/kernels.cuh
@@ -37,4 +37,16 @@ __global__ void checkAllEqualKernel(
     const float* __restrict__ rhs, const TensorLayout rhsLayout,
     int* isEqualFlag, size_t count);
 
+__global__ void iaddKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
+    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
+
+__global__ void isubKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
+    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
+
+__global__ void imulKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
+    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
+    
+__global__ void idivKernel(float* __restrict__ lhs, const TensorLayout lhsLayout, 
+    const float* __restrict__ rhs, const TensorLayout rhsLayout, size_t count);
+
 #endif // KERNELS_CUH

--- a/src/backend/cuda/tensor_impl_CUDA.cu
+++ b/src/backend/cuda/tensor_impl_CUDA.cu
@@ -241,13 +241,19 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::applyReductionKernel(const Tenso
     size_t blockCount = 1;
     for (size_t d = 0; d < blockLayout.rank; d++) blockCount *= blockLayout.shape[d];
 
-    size_t count = blockCount * outCount;
 
-    // initialize output buffer to initValue, then call reduction kernel
+    // kernel params
     int threads = 256;
-    int blocks = (count + threads - 1) / threads;
-    fillKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(out, initValue, outCount);
-    kernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockCount, outLayout, outCount);
+    auto stream = CudaContext::get().stream();
+
+    // initialize output buffer to initValue
+    int fillBlocks = (outCount + threads - 1) / threads;
+    fillKernel<<<fillBlocks, threads, 0, stream>>>(out, initValue, outCount);
+    CUDA_CHECK(cudaGetLastError());
+
+    // call reduction kernel
+    int kernelBlocks = (blockCount * outCount + threads - 1) / threads;
+    kernel<<<kernelBlocks, threads, 0, stream>>>(lhs, out, layout, blockCount, outLayout, outCount);
     CUDA_CHECK(cudaGetLastError());
 
     return std::unique_ptr<Tensor::Impl>(results);

--- a/src/backend/cuda/tensor_impl_CUDA.cu
+++ b/src/backend/cuda/tensor_impl_CUDA.cu
@@ -247,7 +247,7 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::applyReductionKernel(const Tenso
     int threads = 256;
     int blocks = (count + threads - 1) / threads;
     fillKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(out, initValue, outCount);
-    kernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockLayout, blockCount, outLayout, outCount);
+    kernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockCount, outLayout, outCount);
     CUDA_CHECK(cudaGetLastError());
 
     return std::unique_ptr<Tensor::Impl>(results);

--- a/src/backend/cuda/tensor_impl_CUDA.cu
+++ b/src/backend/cuda/tensor_impl_CUDA.cu
@@ -17,6 +17,7 @@ Tensor::CUDAImpl::CUDAImpl(const Tensor::Shape& shape)
     : m_shape(shape) {
     size_t numElements = shape.getNumElements();
     CUDA_CHECK(cudaMalloc((void**)&d_data, numElements * sizeof(float)));
+    CUDA_CHECK(cudaMemset((void**)d_data, 0, numElements * sizeof(float)));
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -259,6 +260,27 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::prod(const TensorLayout& layout,
 
 
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::norm(const TensorLayout& layout) const {
-    return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(layout));
+    // create output tensor
+    auto outShape = Tensor::Shape({1});
+    auto* results = new Tensor::CUDAImpl(outShape);
+
+    // get all data pointers
+    const float* lhs = dataPtr();
+    float* out = results->dataPtr();
+
+    size_t count = 1;
+    for (size_t d = 0; d < layout.rank; d++) count *= layout.shape[d];
+
+    // get sum of all elements squared
+    int threads = 256;
+    int blocks = (count + threads - 1) / threads;
+    squareSumKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, count);
+    CUDA_CHECK(cudaGetLastError());
+
+    // apply sqrt to out
+    isqrtKernel<<<1, 1, 0, CudaContext::get().stream()>>>(out, 1);
+    CUDA_CHECK(cudaGetLastError());
+
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 

--- a/src/backend/cuda/tensor_impl_CUDA.cu
+++ b/src/backend/cuda/tensor_impl_CUDA.cu
@@ -146,7 +146,9 @@ bool Tensor::CUDAImpl::compare(const TensorLayout& lhsLayout, const Tensor::Impl
     return h_equalFlag;
 }
 
-
+const Tensor::CUDAImpl* Tensor::CUDAImpl::cast(const Tensor::Impl* p) const {
+    return static_cast<const Tensor::CUDAImpl*>(p);
+}
 
 template<typename Kernel>
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::applyKernel(
@@ -196,25 +198,40 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::div(const TensorLayout& lhsLayou
     return applyKernel(lhsLayout, rhsImpl, rhsLayout, outLayout, divKernel);
 }
 
-const Tensor::CUDAImpl* Tensor::CUDAImpl::cast(const Tensor::Impl* p) const {
-    return static_cast<const Tensor::CUDAImpl*>(p);
+template<typename Kernel>
+void Tensor::CUDAImpl::applyInplaceKernel(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, 
+                                          const TensorLayout& rhsLayout, Kernel kernel) {
+
+    const Tensor::CUDAImpl* o = cast(rhsImpl);
+
+    // get all data pointers
+    float* lhs = dataPtr();
+    const float* rhs = o->dataPtr();
+
+    size_t count = 1;
+    for (size_t d = 0; d < lhsLayout.rank; d++) count *= lhsLayout.shape[d];
+
+    // launch kernel
+    int threads = 256;
+    int blocks = (count + threads - 1) / threads;
+    kernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, lhsLayout, rhs, rhsLayout, count);
+    CUDA_CHECK(cudaGetLastError());
 }
 
-
 void Tensor::CUDAImpl::iadd(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
-
+    applyInplaceKernel(lhsLayout, rhsImpl, rhsLayout, iaddKernel);
 }   
 
 void Tensor::CUDAImpl::isub(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
-
+    applyInplaceKernel(lhsLayout, rhsImpl, rhsLayout, isubKernel);
 }   
 
 void Tensor::CUDAImpl::imul(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
-
+    applyInplaceKernel(lhsLayout, rhsImpl, rhsLayout, imulKernel);
 }
 
 void Tensor::CUDAImpl::idiv(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
-
+    applyInplaceKernel(lhsLayout, rhsImpl, rhsLayout, idivKernel);
 }
 
 
@@ -244,3 +261,4 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::prod(const TensorLayout& layout,
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::norm(const TensorLayout& layout) const {
     return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(layout));
 }
+

--- a/src/backend/cuda/tensor_impl_CUDA.cu
+++ b/src/backend/cuda/tensor_impl_CUDA.cu
@@ -1,10 +1,8 @@
-#include "tensor_impl_CUDA.h"
+#include <cuda_runtime.h>
 
 #include "backend/cuda/kernels/kernels.cuh"
 #include "backend/cuda/utils/cuda_context.h"
-
-#include <cuda_runtime.h>
-
+#include "tensor_impl_CUDA.h"
 
 Tensor::CUDAImpl::CUDAImpl(const Tensor::Shape& shape)
     : m_shape(shape) {
@@ -19,9 +17,7 @@ Tensor::CUDAImpl::~CUDAImpl() {
 }
 
 void Tensor::CUDAImpl::fillAll(float value) {
-    int threads = 256;
-    int blocks = std::max(1, ((int)m_shape.getNumElements() + threads - 1) / threads);
-    fillKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(d_data, value, (unsigned int)m_shape.getNumElements());
+    fillKernel<<<getNumCUDABlocks(m_shape.getNumElements()), BLOCK_SIZE, 0, CudaContext::get().stream()>>>(d_data, value, m_shape.getNumElements());
 }
 
 void Tensor::CUDAImpl::fillRand() {
@@ -101,9 +97,7 @@ void Tensor::CUDAImpl::set(const TensorLayout& lhsLayout, const Tensor::Impl* rh
     size_t count = 1;
     for (size_t d = 0; d < rhsLayout.rank; d++) count *= rhsLayout.shape[d];
 
-    int threads = 256;
-    int blocks = ((int)count + threads - 1) / threads;
-    setKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(a, lhsLayout, b, rhsLayout, (int)count);
+    setKernel<<<getNumCUDABlocks(count), BLOCK_SIZE, 0, CudaContext::get().stream()>>>(a, lhsLayout, b, rhsLayout, (int)count);
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -126,9 +120,7 @@ bool Tensor::CUDAImpl::compare(const TensorLayout& lhsLayout, const Tensor::Impl
     for (size_t d = 0; d < rhsLayout.rank; d++) count *= rhsLayout.shape[d];
 
     // launch kernel
-    int threads = 256;
-    int blocks = (count + threads - 1) / threads;
-    checkAllEqualKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhsDataPtr, lhsLayout, rhsDataPtr, rhsLayout, d_equalFlag, count);
+    checkAllEqualKernel<<<getNumCUDABlocks(count), BLOCK_SIZE, 0, CudaContext::get().stream()>>>(lhsDataPtr, lhsLayout, rhsDataPtr, rhsLayout, d_equalFlag, count);
     CUDA_CHECK(cudaGetLastError());
 
     // copy flag from device
@@ -160,9 +152,7 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::applyKernel(
     for (size_t d = 0; d < outLayout.rank; d++) count *= outLayout.shape[d];
 
     // launch kernel
-    int threads = 256;
-    int blocks = (count + threads - 1) / threads;
-    kernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, lhsLayout, rhs, rhsLayout, out, outLayout, count);
+    kernel<<<getNumCUDABlocks(count), BLOCK_SIZE, 0, CudaContext::get().stream()>>>(lhs, lhsLayout, rhs, rhsLayout, out, outLayout, count);
     CUDA_CHECK(cudaGetLastError());
 
     return std::unique_ptr<Tensor::Impl>(results);
@@ -201,9 +191,7 @@ void Tensor::CUDAImpl::applyInplaceKernel(const TensorLayout& lhsLayout, const T
     for (size_t d = 0; d < lhsLayout.rank; d++) count *= lhsLayout.shape[d];
 
     // launch kernel
-    int threads = 256;
-    int blocks = (count + threads - 1) / threads;
-    kernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, lhsLayout, rhs, rhsLayout, count);
+    kernel<<<getNumCUDABlocks(count), BLOCK_SIZE, 0, CudaContext::get().stream()>>>(lhs, lhsLayout, rhs, rhsLayout, count);
     CUDA_CHECK(cudaGetLastError());
 }
 
@@ -241,19 +229,12 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::applyReductionKernel(const Tenso
     size_t blockCount = 1;
     for (size_t d = 0; d < blockLayout.rank; d++) blockCount *= blockLayout.shape[d];
 
-
-    // kernel params
-    int threads = 256;
-    auto stream = CudaContext::get().stream();
-
     // initialize output buffer to initValue
-    int fillBlocks = (outCount + threads - 1) / threads;
-    fillKernel<<<fillBlocks, threads, 0, stream>>>(out, initValue, outCount);
+    fillKernel<<<getNumCUDABlocks(outCount), BLOCK_SIZE, 0, CudaContext::get().stream()>>>(out, initValue, outCount);
     CUDA_CHECK(cudaGetLastError());
 
     // call reduction kernel
-    int kernelBlocks = (blockCount * outCount + threads - 1) / threads;
-    kernel<<<kernelBlocks, threads, 0, stream>>>(lhs, out, layout, blockCount, outLayout, outCount);
+    kernel<<<getNumCUDABlocks(blockCount * outCount), BLOCK_SIZE, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockCount, outLayout, outCount);
     CUDA_CHECK(cudaGetLastError());
 
     return std::unique_ptr<Tensor::Impl>(results);
@@ -292,9 +273,7 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::norm(const TensorLayout& layout)
     for (size_t d = 0; d < layout.rank; d++) count *= layout.shape[d];
 
     // get sum of all elements squared
-    int threads = 256;
-    int blocks = (count + threads - 1) / threads;
-    squareSumKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, count);
+    squareSumKernel<<<getNumCUDABlocks(count), BLOCK_SIZE, 0, CudaContext::get().stream()>>>(lhs, out, count);
     CUDA_CHECK(cudaGetLastError());
 
     // apply sqrt to out

--- a/src/backend/cuda/tensor_impl_CUDA.cu
+++ b/src/backend/cuda/tensor_impl_CUDA.cu
@@ -225,7 +225,7 @@ void Tensor::CUDAImpl::idiv(const TensorLayout& lhsLayout, const Tensor::Impl* r
 
 template <typename Kernel>
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::applyReductionKernel(const TensorLayout& layout, const TensorLayout& blockLayout,
-                                                                     const TensorLayout& outLayout, Kernel kernel) const {
+                                                                     const TensorLayout& outLayout, float initValue, Kernel kernel) const {
     // create output tensor
     auto outShape = Tensor::Shape(outLayout);
     auto* results = new Tensor::CUDAImpl(outShape);
@@ -243,11 +243,10 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::applyReductionKernel(const Tenso
 
     size_t count = blockCount * outCount;
 
-    // Initialize output buffer to 0 (will be set to proper identity values in kernels if needed)
-    CUDA_CHECK(cudaMemset(out, 0, outCount * sizeof(float)));
-
+    // initialize output buffer to initValue, then call reduction kernel
     int threads = 256;
     int blocks = (count + threads - 1) / threads;
+    fillKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(out, initValue, outCount);
     kernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockLayout, blockCount, outLayout, outCount);
     CUDA_CHECK(cudaGetLastError());
 
@@ -256,100 +255,22 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::applyReductionKernel(const Tenso
 
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::sum(const TensorLayout& layout, const TensorLayout& blockLayout,
                                                     const TensorLayout& outLayout) const {
-    return applyReductionKernel(layout, blockLayout, outLayout, sumReductionKernel);
+    return applyReductionKernel(layout, blockLayout, outLayout, 0.0f, sumReductionKernel);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::min(const TensorLayout& layout, const TensorLayout& blockLayout,
                                                     const TensorLayout& outLayout) const {
-    // create output tensor
-    auto outShape = Tensor::Shape(outLayout);
-    auto* results = new Tensor::CUDAImpl(outShape);
-
-    const float* lhs = dataPtr();
-    float* out = results->dataPtr();
-
-    // number of elements in output tensor
-    size_t outCount = 1;
-    for (size_t d = 0; d < outLayout.rank; d++) outCount *= outLayout.shape[d];
-
-    // size of each block to be reduced
-    size_t blockCount = 1;
-    for (size_t d = 0; d < blockLayout.rank; d++) blockCount *= blockLayout.shape[d];
-
-    size_t count = blockCount * outCount;
-
-    // Initialize output buffer to FLT_MAX for min reduction
-    std::vector<float> initValues(outCount, FLT_MAX);
-    CUDA_CHECK(cudaMemcpy(out, initValues.data(), outCount * sizeof(float), cudaMemcpyHostToDevice));
-
-    int threads = 256;
-    int blocks = (count + threads - 1) / threads;
-    minReductionKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockLayout, blockCount, outLayout, outCount);
-    CUDA_CHECK(cudaGetLastError());
-
-    return std::unique_ptr<Tensor::Impl>(results);
+    return applyReductionKernel(layout, blockLayout, outLayout, FLT_MAX, minReductionKernel);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::max(const TensorLayout& layout, const TensorLayout& blockLayout,
                                                     const TensorLayout& outLayout) const {
-    // create output tensor
-    auto outShape = Tensor::Shape(outLayout);
-    auto* results = new Tensor::CUDAImpl(outShape);
-
-    const float* lhs = dataPtr();
-    float* out = results->dataPtr();
-
-    // number of elements in output tensor
-    size_t outCount = 1;
-    for (size_t d = 0; d < outLayout.rank; d++) outCount *= outLayout.shape[d];
-
-    // size of each block to be reduced
-    size_t blockCount = 1;
-    for (size_t d = 0; d < blockLayout.rank; d++) blockCount *= blockLayout.shape[d];
-
-    size_t count = blockCount * outCount;
-
-    // Initialize output buffer to -FLT_MAX for max reduction
-    std::vector<float> initValues(outCount, -FLT_MAX);
-    CUDA_CHECK(cudaMemcpy(out, initValues.data(), outCount * sizeof(float), cudaMemcpyHostToDevice));
-
-    int threads = 256;
-    int blocks = (count + threads - 1) / threads;
-    maxReductionKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockLayout, blockCount, outLayout, outCount);
-    CUDA_CHECK(cudaGetLastError());
-
-    return std::unique_ptr<Tensor::Impl>(results);
+    return applyReductionKernel(layout, blockLayout, outLayout, -FLT_MAX, maxReductionKernel);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::prod(const TensorLayout& layout, const TensorLayout& blockLayout,
                                                      const TensorLayout& outLayout) const {
-    // create output tensor
-    auto outShape = Tensor::Shape(outLayout);
-    auto* results = new Tensor::CUDAImpl(outShape);
-
-    const float* lhs = dataPtr();
-    float* out = results->dataPtr();
-
-    // number of elements in output tensor
-    size_t outCount = 1;
-    for (size_t d = 0; d < outLayout.rank; d++) outCount *= outLayout.shape[d];
-
-    // size of each block to be reduced
-    size_t blockCount = 1;
-    for (size_t d = 0; d < blockLayout.rank; d++) blockCount *= blockLayout.shape[d];
-
-    size_t count = blockCount * outCount;
-
-    // Initialize output buffer to 1.0 for product reduction
-    std::vector<float> initValues(outCount, 1.0f);
-    CUDA_CHECK(cudaMemcpy(out, initValues.data(), outCount * sizeof(float), cudaMemcpyHostToDevice));
-
-    int threads = 256;
-    int blocks = (count + threads - 1) / threads;
-    prodReductionKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockLayout, blockCount, outLayout, outCount);
-    CUDA_CHECK(cudaGetLastError());
-
-    return std::unique_ptr<Tensor::Impl>(results);
+    return applyReductionKernel(layout, blockLayout, outLayout, 1.0f, prodReductionKernel);
 }
 
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::norm(const TensorLayout& layout) const {

--- a/src/backend/cuda/tensor_impl_CUDA.cu
+++ b/src/backend/cuda/tensor_impl_CUDA.cu
@@ -1,19 +1,12 @@
 #include "tensor_impl_CUDA.h"
 
-#include <algorithm>
-#include <random>
-#include <sstream>
-#include <iostream>
-
-#include "nforge/core/tensor.h"
 #include "backend/cuda/kernels/kernels.cuh"
-#include "backend/cuda/utils/cuda_error.h"
 #include "backend/cuda/utils/cuda_context.h"
 
 #include <cuda_runtime.h>
 
 
-Tensor::CUDAImpl::CUDAImpl(const Tensor::Shape& shape) 
+Tensor::CUDAImpl::CUDAImpl(const Tensor::Shape& shape)
     : m_shape(shape) {
     size_t numElements = shape.getNumElements();
     CUDA_CHECK(cudaMalloc((void**)&d_data, numElements * sizeof(float)));
@@ -27,7 +20,7 @@ Tensor::CUDAImpl::~CUDAImpl() {
 
 void Tensor::CUDAImpl::fillAll(float value) {
     int threads = 256;
-    int blocks  = std::max(1, ((int)m_shape.getNumElements() + threads - 1) / threads);
+    int blocks = std::max(1, ((int)m_shape.getNumElements() + threads - 1) / threads);
     fillKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(d_data, value, (unsigned int)m_shape.getNumElements());
 }
 
@@ -85,7 +78,7 @@ std::string Tensor::CUDAImpl::toString() const {
 
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::clone() const {
     CUDAImpl* copy = new CUDAImpl(m_shape);
-    
+
     // sync
     CUDA_CHECK(cudaGetLastError());
     CUDA_CHECK(cudaStreamSynchronize(CudaContext::get().stream()));
@@ -98,14 +91,13 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::clone() const {
 }
 
 // Assignments and indexing
-void Tensor::CUDAImpl::set(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, 
-                          const TensorLayout& rhsLayout) {
-
+void Tensor::CUDAImpl::set(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl,
+                           const TensorLayout& rhsLayout) {
     const Tensor::CUDAImpl* o = cast(rhsImpl);
 
     float* a = dataPtr();
     float* b = o->dataPtr();
-    
+
     size_t count = 1;
     for (size_t d = 0; d < rhsLayout.rank; d++) count *= rhsLayout.shape[d];
 
@@ -116,12 +108,12 @@ void Tensor::CUDAImpl::set(const TensorLayout& lhsLayout, const Tensor::Impl* rh
 }
 
 // Comparisons
-bool Tensor::CUDAImpl::compare(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, 
-                              const TensorLayout& rhsLayout) const {
+bool Tensor::CUDAImpl::compare(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl,
+                               const TensorLayout& rhsLayout) const {
     const Tensor::CUDAImpl* o = cast(rhsImpl);
 
     // init equal flag
-    int h_equalFlag = 1; 
+    int h_equalFlag = 1;
     int* d_equalFlag;
     cudaMalloc(&d_equalFlag, sizeof(int));
     cudaMemcpy(d_equalFlag, &h_equalFlag, sizeof(int), cudaMemcpyHostToDevice);
@@ -130,7 +122,6 @@ bool Tensor::CUDAImpl::compare(const TensorLayout& lhsLayout, const Tensor::Impl
     const float* lhsDataPtr = dataPtr();
     const float* rhsDataPtr = o->dataPtr();
 
-    
     size_t count = 1;
     for (size_t d = 0; d < rhsLayout.rank; d++) count *= rhsLayout.shape[d];
 
@@ -139,7 +130,6 @@ bool Tensor::CUDAImpl::compare(const TensorLayout& lhsLayout, const Tensor::Impl
     int blocks = (count + threads - 1) / threads;
     checkAllEqualKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhsDataPtr, lhsLayout, rhsDataPtr, rhsLayout, d_equalFlag, count);
     CUDA_CHECK(cudaGetLastError());
-
 
     // copy flag from device
     cudaMemcpy(&h_equalFlag, d_equalFlag, sizeof(int), cudaMemcpyDeviceToHost);
@@ -151,11 +141,10 @@ const Tensor::CUDAImpl* Tensor::CUDAImpl::cast(const Tensor::Impl* p) const {
     return static_cast<const Tensor::CUDAImpl*>(p);
 }
 
-template<typename Kernel>
+template <typename Kernel>
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::applyKernel(
-    const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, 
+    const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl,
     const TensorLayout& rhsLayout, const TensorLayout& outLayout, Kernel kernel) const {
-
     // create output tensor
     auto outShape = Tensor::Shape(outLayout);
     auto* results = new Tensor::CUDAImpl(outLayout);
@@ -199,10 +188,9 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::div(const TensorLayout& lhsLayou
     return applyKernel(lhsLayout, rhsImpl, rhsLayout, outLayout, divKernel);
 }
 
-template<typename Kernel>
-void Tensor::CUDAImpl::applyInplaceKernel(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, 
+template <typename Kernel>
+void Tensor::CUDAImpl::applyInplaceKernel(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl,
                                           const TensorLayout& rhsLayout, Kernel kernel) {
-
     const Tensor::CUDAImpl* o = cast(rhsImpl);
 
     // get all data pointers
@@ -221,11 +209,11 @@ void Tensor::CUDAImpl::applyInplaceKernel(const TensorLayout& lhsLayout, const T
 
 void Tensor::CUDAImpl::iadd(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
     applyInplaceKernel(lhsLayout, rhsImpl, rhsLayout, iaddKernel);
-}   
+}
 
 void Tensor::CUDAImpl::isub(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
     applyInplaceKernel(lhsLayout, rhsImpl, rhsLayout, isubKernel);
-}   
+}
 
 void Tensor::CUDAImpl::imul(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
     applyInplaceKernel(lhsLayout, rhsImpl, rhsLayout, imulKernel);
@@ -235,29 +223,134 @@ void Tensor::CUDAImpl::idiv(const TensorLayout& lhsLayout, const Tensor::Impl* r
     applyInplaceKernel(lhsLayout, rhsImpl, rhsLayout, idivKernel);
 }
 
+template <typename Kernel>
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::applyReductionKernel(const TensorLayout& layout, const TensorLayout& blockLayout,
+                                                                     const TensorLayout& outLayout, Kernel kernel) const {
+    // create output tensor
+    auto outShape = Tensor::Shape(outLayout);
+    auto* results = new Tensor::CUDAImpl(outShape);
 
-std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::sum(const TensorLayout& layout, const TensorLayout& blockLayout, 
-                                                    const TensorLayout& outLayout) const {
-    return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(outLayout));
+    const float* lhs = dataPtr();
+    float* out = results->dataPtr();
+
+    // number of elements in output tensor
+    size_t outCount = 1;
+    for (size_t d = 0; d < outLayout.rank; d++) outCount *= outLayout.shape[d];
+
+    // size of each block to be reduced
+    size_t blockCount = 1;
+    for (size_t d = 0; d < blockLayout.rank; d++) blockCount *= blockLayout.shape[d];
+
+    size_t count = blockCount * outCount;
+
+    // Initialize output buffer to 0 (will be set to proper identity values in kernels if needed)
+    CUDA_CHECK(cudaMemset(out, 0, outCount * sizeof(float)));
+
+    int threads = 256;
+    int blocks = (count + threads - 1) / threads;
+    kernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockLayout, blockCount, outLayout, outCount);
+    CUDA_CHECK(cudaGetLastError());
+
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 
-std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::min(const TensorLayout& layout, const TensorLayout& blockLayout, 
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::sum(const TensorLayout& layout, const TensorLayout& blockLayout,
                                                     const TensorLayout& outLayout) const {
-    return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(outLayout));
+    return applyReductionKernel(layout, blockLayout, outLayout, sumReductionKernel);
 }
 
-
-std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::max(const TensorLayout& layout, const TensorLayout& blockLayout, 
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::min(const TensorLayout& layout, const TensorLayout& blockLayout,
                                                     const TensorLayout& outLayout) const {
-    return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(outLayout));
+    // create output tensor
+    auto outShape = Tensor::Shape(outLayout);
+    auto* results = new Tensor::CUDAImpl(outShape);
+
+    const float* lhs = dataPtr();
+    float* out = results->dataPtr();
+
+    // number of elements in output tensor
+    size_t outCount = 1;
+    for (size_t d = 0; d < outLayout.rank; d++) outCount *= outLayout.shape[d];
+
+    // size of each block to be reduced
+    size_t blockCount = 1;
+    for (size_t d = 0; d < blockLayout.rank; d++) blockCount *= blockLayout.shape[d];
+
+    size_t count = blockCount * outCount;
+
+    // Initialize output buffer to FLT_MAX for min reduction
+    std::vector<float> initValues(outCount, FLT_MAX);
+    CUDA_CHECK(cudaMemcpy(out, initValues.data(), outCount * sizeof(float), cudaMemcpyHostToDevice));
+
+    int threads = 256;
+    int blocks = (count + threads - 1) / threads;
+    minReductionKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockLayout, blockCount, outLayout, outCount);
+    CUDA_CHECK(cudaGetLastError());
+
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 
-
-std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::prod(const TensorLayout& layout, const TensorLayout& blockLayout, 
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::max(const TensorLayout& layout, const TensorLayout& blockLayout,
                                                     const TensorLayout& outLayout) const {
-    return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(outLayout));
+    // create output tensor
+    auto outShape = Tensor::Shape(outLayout);
+    auto* results = new Tensor::CUDAImpl(outShape);
+
+    const float* lhs = dataPtr();
+    float* out = results->dataPtr();
+
+    // number of elements in output tensor
+    size_t outCount = 1;
+    for (size_t d = 0; d < outLayout.rank; d++) outCount *= outLayout.shape[d];
+
+    // size of each block to be reduced
+    size_t blockCount = 1;
+    for (size_t d = 0; d < blockLayout.rank; d++) blockCount *= blockLayout.shape[d];
+
+    size_t count = blockCount * outCount;
+
+    // Initialize output buffer to -FLT_MAX for max reduction
+    std::vector<float> initValues(outCount, -FLT_MAX);
+    CUDA_CHECK(cudaMemcpy(out, initValues.data(), outCount * sizeof(float), cudaMemcpyHostToDevice));
+
+    int threads = 256;
+    int blocks = (count + threads - 1) / threads;
+    maxReductionKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockLayout, blockCount, outLayout, outCount);
+    CUDA_CHECK(cudaGetLastError());
+
+    return std::unique_ptr<Tensor::Impl>(results);
 }
 
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::prod(const TensorLayout& layout, const TensorLayout& blockLayout,
+                                                     const TensorLayout& outLayout) const {
+    // create output tensor
+    auto outShape = Tensor::Shape(outLayout);
+    auto* results = new Tensor::CUDAImpl(outShape);
+
+    const float* lhs = dataPtr();
+    float* out = results->dataPtr();
+
+    // number of elements in output tensor
+    size_t outCount = 1;
+    for (size_t d = 0; d < outLayout.rank; d++) outCount *= outLayout.shape[d];
+
+    // size of each block to be reduced
+    size_t blockCount = 1;
+    for (size_t d = 0; d < blockLayout.rank; d++) blockCount *= blockLayout.shape[d];
+
+    size_t count = blockCount * outCount;
+
+    // Initialize output buffer to 1.0 for product reduction
+    std::vector<float> initValues(outCount, 1.0f);
+    CUDA_CHECK(cudaMemcpy(out, initValues.data(), outCount * sizeof(float), cudaMemcpyHostToDevice));
+
+    int threads = 256;
+    int blocks = (count + threads - 1) / threads;
+    prodReductionKernel<<<blocks, threads, 0, CudaContext::get().stream()>>>(lhs, out, layout, blockLayout, blockCount, outLayout, outCount);
+    CUDA_CHECK(cudaGetLastError());
+
+    return std::unique_ptr<Tensor::Impl>(results);
+}
 
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::norm(const TensorLayout& layout) const {
     // create output tensor
@@ -283,4 +376,3 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::norm(const TensorLayout& layout)
 
     return std::unique_ptr<Tensor::Impl>(results);
 }
-

--- a/src/backend/cuda/tensor_impl_CUDA.cu
+++ b/src/backend/cuda/tensor_impl_CUDA.cu
@@ -199,3 +199,48 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::div(const TensorLayout& lhsLayou
 const Tensor::CUDAImpl* Tensor::CUDAImpl::cast(const Tensor::Impl* p) const {
     return static_cast<const Tensor::CUDAImpl*>(p);
 }
+
+
+void Tensor::CUDAImpl::iadd(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
+
+}   
+
+void Tensor::CUDAImpl::isub(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
+
+}   
+
+void Tensor::CUDAImpl::imul(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
+
+}
+
+void Tensor::CUDAImpl::idiv(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) {
+
+}
+
+
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::sum(const TensorLayout& layout, const TensorLayout& blockLayout, 
+                                                    const TensorLayout& outLayout) const {
+    return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(outLayout));
+}
+
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::min(const TensorLayout& layout, const TensorLayout& blockLayout, 
+                                                    const TensorLayout& outLayout) const {
+    return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(outLayout));
+}
+
+
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::max(const TensorLayout& layout, const TensorLayout& blockLayout, 
+                                                    const TensorLayout& outLayout) const {
+    return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(outLayout));
+}
+
+
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::prod(const TensorLayout& layout, const TensorLayout& blockLayout, 
+                                                    const TensorLayout& outLayout) const {
+    return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(outLayout));
+}
+
+
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::norm(const TensorLayout& layout) const {
+    return std::unique_ptr<Tensor::Impl>(new Tensor::CUDAImpl(layout));
+}

--- a/src/backend/cuda/tensor_impl_CUDA.h
+++ b/src/backend/cuda/tensor_impl_CUDA.h
@@ -87,7 +87,7 @@ class Tensor::CUDAImpl : public Tensor::Impl {
     // reduction must be associative
     template <typename Kernel>
     std::unique_ptr<Tensor::Impl> applyReductionKernel(const TensorLayout& layout, const TensorLayout& blockLayout,
-                                                       const TensorLayout& outLayout, Kernel kernel) const;
+                                                       const TensorLayout& outLayout, float initValue, Kernel kernel) const;
 
 };
 

--- a/src/backend/cuda/tensor_impl_CUDA.h
+++ b/src/backend/cuda/tensor_impl_CUDA.h
@@ -79,6 +79,12 @@ class Tensor::CUDAImpl : public Tensor::Impl {
     template <typename Kernel>
     std::unique_ptr<Tensor::Impl> applyKernel(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, 
                                               const TensorLayout& rhsLayout, const TensorLayout& outLayout, Kernel kernel) const;
+      
+    template <typename Kernel>
+    void applyInplaceKernel(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, 
+                            const TensorLayout& rhsLayout, Kernel kernel);
+
+
 };
 
 #endif  // TENSOR_IMPL_CUDA_H

--- a/src/backend/cuda/tensor_impl_CUDA.h
+++ b/src/backend/cuda/tensor_impl_CUDA.h
@@ -48,6 +48,27 @@ class Tensor::CUDAImpl : public Tensor::Impl {
 
     std::unique_ptr<Tensor::Impl> div(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, 
                                       const TensorLayout& rhsLayout, const TensorLayout& outLayout) const override;
+
+
+    void iadd(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) override;    
+    void isub(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) override;    
+    void imul(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) override;
+    void idiv(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, const TensorLayout& rhsLayout) override;
+
+    std::unique_ptr<Tensor::Impl> sum(const TensorLayout& layout, const TensorLayout& blockLayout, 
+                                      const TensorLayout& outLayout) const override;
+
+    std::unique_ptr<Tensor::Impl> min(const TensorLayout& layout, const TensorLayout& blockLayout, 
+                                      const TensorLayout& outLayout) const override;
+
+    std::unique_ptr<Tensor::Impl> max(const TensorLayout& layout, const TensorLayout& blockLayout, 
+                                      const TensorLayout& outLayout) const override;
+
+    std::unique_ptr<Tensor::Impl> prod(const TensorLayout& layout, const TensorLayout& blockLayout, 
+                                       const TensorLayout& outLayout) const override;
+    
+    std::unique_ptr<Tensor::Impl> norm(const TensorLayout& layout) const override;
+    
    private:
     Tensor::Shape m_shape;
     float* d_data;
@@ -60,4 +81,4 @@ class Tensor::CUDAImpl : public Tensor::Impl {
                                               const TensorLayout& rhsLayout, const TensorLayout& outLayout, Kernel kernel) const;
 };
 
-#endif  // TENSOR_IMPL_CPU_H
+#endif  // TENSOR_IMPL_CUDA_H

--- a/src/backend/cuda/tensor_impl_CUDA.h
+++ b/src/backend/cuda/tensor_impl_CUDA.h
@@ -84,6 +84,10 @@ class Tensor::CUDAImpl : public Tensor::Impl {
     void applyInplaceKernel(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl, 
                             const TensorLayout& rhsLayout, Kernel kernel);
 
+    // reduction must be associative
+    template <typename Kernel>
+    std::unique_ptr<Tensor::Impl> applyReductionKernel(const TensorLayout& layout, const TensorLayout& blockLayout,
+                                                       const TensorLayout& outLayout, Kernel kernel) const;
 
 };
 

--- a/src/backend/cuda/utils/cuda_utils.h
+++ b/src/backend/cuda/utils/cuda_utils.h
@@ -1,0 +1,10 @@
+#ifndef NFORGE_CUDA_UTILS_H
+#define NFORGE_CUDA_UTILS_H
+
+static constexpr int BLOCK_SIZE = 256;
+
+constexpr int getNumCUDABlocks(size_t count) {
+    return (count + BLOCK_SIZE - 1) / BLOCK_SIZE;
+}
+
+#endif  // NFORGE_CUDA_UTILS_H

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -195,6 +195,17 @@ Tensor::View Tensor::View::operator=(const Tensor::View& rhs) {
     return *this;
 }
 
+Tensor::View Tensor::View::operator=(float scalar) {
+    if (!this->getShape().isScalar()) {
+        throw std::runtime_error("Cannot assign float to a non-scalar tensor.");
+    }
+
+    *this = Tensor(this->getShape(), scalar, m_parent.getBackend());
+
+    return *this;
+}
+
+
 Tensor::View Tensor::View::operator[](size_t idx) const {
     auto ctx = semantic::validateIndexing(*this, idx);
 

--- a/tests/unit/test_reductions.cpp
+++ b/tests/unit/test_reductions.cpp
@@ -153,6 +153,7 @@ TEST_CASE("Tensor mean reduction by sum reduction", "[Tensor]") {
         size_t count = 4 * 5 * 8;
         for (size_t d = 0; d <= 3; d++) {
             Tensor sum = a.sum(d);
+            REQUIRE(sum != Tensor(0, backend)); // sanity check
             REQUIRE(a.mean(d) == sum / count);
             
             if (d != 3) {

--- a/tests/unit/test_reductions.cpp
+++ b/tests/unit/test_reductions.cpp
@@ -95,7 +95,7 @@ TEST_CASE("Tensor min reduction", "[Tensor]") {
         
         for (size_t i = 0; i < 2; i++) {
             for (size_t j = 0; j < 3; j++) {
-                a[i][j] = Tensor(i * 3 + j);
+                a[i][j] = Tensor(i * 3 + j, backend);
             }
         }
         // a = [[0, 1, 2], [3, 4, 5]]
@@ -153,8 +153,15 @@ TEST_CASE("Tensor mean reduction by sum reduction", "[Tensor]") {
         size_t count = 4 * 5 * 8;
         for (size_t d = 0; d <= 3; d++) {
             Tensor sum = a.sum(d);
+
             REQUIRE(sum != Tensor(0, backend)); // sanity check
-            REQUIRE(a.mean(d) == sum / count);
+
+            // TODO: refactor with relative comparison and tolerance
+            Tensor targetMean = sum / count;
+            Tensor diff = a.mean(d) - targetMean;
+            Tensor absDiff = diff * diff;
+            Tensor maxDiff = absDiff.max();
+            REQUIRE(maxDiff.toVector()[0] < 1e-6f);
             
             if (d != 3) {
                 count /= shape[d];

--- a/tests/unit/test_tensor.cpp
+++ b/tests/unit/test_tensor.cpp
@@ -401,17 +401,19 @@ TEST_CASE("Verify frobenius norm return tensor", "[Tensor]") {
     }
 }
 
-
 TEST_CASE("Frobenius norm of scalar", "[Tensor]") {
     auto backend = GENERATE(from_range(backends));
 
     DYNAMIC_SECTION(getBackendString(backend)) {
-        Tensor a(4.0f, backend);
-        Tensor b(-4.0f, backend);
-        
+        SECTION("Positive scalar") {
+            Tensor a(4.0f, backend);
+            REQUIRE(a.norm() == Tensor(4.0f, backend));
+        }
 
-        REQUIRE(a.norm() == Tensor(4.0f, backend));
-        REQUIRE(b.norm() == Tensor(4.0f, backend));
+        SECTION("Negative scalar") {
+            Tensor b(-4.0f, backend);
+            REQUIRE(b.norm() == Tensor(4.0f, backend));
+        }
     }
 }
 
@@ -420,20 +422,16 @@ TEST_CASE("Frobenius norm of vector", "[Tensor]") {
     auto backend = GENERATE(from_range(backends));
 
     DYNAMIC_SECTION(getBackendString(backend)) {
-        // Test with constant value
-        Tensor a({5}, -4.0f, backend);
-        float norm = 4.0f * std::sqrt(5);
-
-        REQUIRE(a.norm() == Tensor(norm, backend));
-
-        
-        // Test with non constant value
-        for (size_t i = 0; i < 5; i++) {
-            a[i] = i;
+        SECTION("Uniform values") {
+            Tensor a({5}, -4.0f, backend);
+            REQUIRE(a.norm() == Tensor(4.0f * std::sqrt(5.0f), backend));
         }
-        // a = [0, 1, 2, 3, 4]
 
-        REQUIRE(a.norm() == Tensor(std::sqrt(30.0f), backend));
+        SECTION("Sequential values [0, 1, 2, 3, 4]") {
+            Tensor a({5}, 0.0f, backend);
+            for (size_t i = 0; i < 5; i++) a[i] = i;
+            REQUIRE(a.norm() == Tensor(std::sqrt(30.0f), backend));
+        }
     }
 }
 
@@ -442,46 +440,51 @@ TEST_CASE("Frobenius norm of matrix", "[Tensor]") {
     auto backend = GENERATE(from_range(backends));
 
     DYNAMIC_SECTION(getBackendString(backend)) {
-        size_t n = 5;
-        size_t m = 8;
-        Tensor a({n, m}, -4.0f, backend);
-
-        float targetNorm = 4.0f * std::sqrt(n * m);
-        REQUIRE(a.norm() == Tensor(targetNorm, backend));
-
-        float sum = 0;
-        for (size_t i = 0; i < n; i++) {
-            for (size_t j = 0; j < m; j++) {
-                a[i][j] = i * m + j;
-                sum += std::pow(i * m + j, 2);
-            }
+        SECTION("Uniform values") {
+            Tensor a({5, 8}, -4.0f, backend);
+            REQUIRE(a.norm() == Tensor(4.0f * std::sqrt(5.0f * 8.0f), backend));
         }
-        
-        REQUIRE(a.norm() == Tensor(std::sqrt(sum), backend));
+
+        SECTION("Sequential values") {
+            Tensor a({5, 8}, 0.0f, backend);
+            
+            float sum = 0;
+            for (size_t i = 0; i < 5; i++) {
+                for (size_t j = 0; j < 8; j++) {
+                    a[i][j] = i * 8 + j;
+                    sum += std::pow(i * 8 + j, 2);
+                }
+            }
+
+            REQUIRE(a.norm() == Tensor(std::sqrt(sum), backend));
+        }
     }
 }
 
-TEST_CASE("Frobenius norm of random tensor", "[Tensor]") {
+TEST_CASE("Frobenius norm of 4-rank tensor", "[Tensor]") {
     auto backend = GENERATE(from_range(backends));
 
     DYNAMIC_SECTION(getBackendString(backend)) {
-        Tensor a({8, 9, 4, 3}, -4.0f, backend);
-
-        float targetNorm = 4.0f * std::sqrt(8 * 9 * 4 * 3);
-        REQUIRE(a.norm() == Tensor(targetNorm, backend));
-
-
-        a.fillRand();
-
-        float sum = 0;
-        const auto elements = a.toVector();
-        for (float e : elements) {
-            sum += e * e;
+        SECTION("Uniform values") {
+            Tensor a({8, 9, 4, 3}, -4.0f, backend);
+            REQUIRE(a.norm() == Tensor(4.0f * std::sqrt(8.0f * 9.0f * 4.0f * 3.0f), backend));
         }
         
-        // random tensor has a lot of noise, so use relative error
-        Tensor ratio = a.norm() / std::sqrt(sum);
-        REQUIRE(ratio.toVector()[0] > 0.99);
-        REQUIRE(ratio.toVector()[0] < 1.01);
+        SECTION("Random values") {
+            Tensor a({8, 9, 4, 3}, backend);
+
+            a.fillRand();
+
+            float sum = 0;
+            const auto elements = a.toVector();
+            for (float e : elements) {
+                sum += e * e;
+            }
+        
+            // random tensor has a lot of noise, so use relative error
+            Tensor ratio = a.norm() / std::sqrt(sum);
+            REQUIRE(ratio.toVector()[0] > 0.99);
+            REQUIRE(ratio.toVector()[0] < 1.01);
+        }
     }
 }

--- a/tests/unit/test_tensor.cpp
+++ b/tests/unit/test_tensor.cpp
@@ -424,13 +424,19 @@ TEST_CASE("Frobenius norm of vector", "[Tensor]") {
     DYNAMIC_SECTION(getBackendString(backend)) {
         SECTION("Uniform values") {
             Tensor a({5}, -4.0f, backend);
-            REQUIRE(a.norm() == Tensor(4.0f * std::sqrt(5.0f), backend));
+
+            // TODO: refactor with relative comparison and tolerance
+            Tensor diff = a.norm() - Tensor(4.0f * std::sqrt(5.0f), backend);
+            REQUIRE(abs(diff.toVector()[0]) < 1e-6f);
         }
 
         SECTION("Sequential values [0, 1, 2, 3, 4]") {
             Tensor a({5}, 0.0f, backend);
             for (size_t i = 0; i < 5; i++) a[i] = i;
-            REQUIRE(a.norm() == Tensor(std::sqrt(30.0f), backend));
+
+            // TODO: refactor with relative comparison and tolerance
+            Tensor diff = a.norm() - Tensor(std::sqrt(30.0f), backend);
+            REQUIRE(abs(diff.toVector()[0]) < 1e-6f);
         }
     }
 }

--- a/tests/unit/test_tensor.cpp
+++ b/tests/unit/test_tensor.cpp
@@ -420,18 +420,19 @@ TEST_CASE("Frobenius norm of vector", "[Tensor]") {
     auto backend = GENERATE(from_range(backends));
 
     DYNAMIC_SECTION(getBackendString(backend)) {
+        // Test with constant value
         Tensor a({5}, -4.0f, backend);
-
         float norm = 4.0f * std::sqrt(5);
-        REQUIRE(a.norm() == Tensor(norm, backend));
-        REQUIRE(a.norm().getShape() == Tensor::Shape({1}));
-        
 
+        REQUIRE(a.norm() == Tensor(norm, backend));
+
+        
+        // Test with non constant value
         for (size_t i = 0; i < 5; i++) {
             a[i] = i;
         }
-
         // a = [0, 1, 2, 3, 4]
+
         REQUIRE(a.norm() == Tensor(std::sqrt(30.0f), backend));
     }
 }
@@ -445,10 +446,8 @@ TEST_CASE("Frobenius norm of matrix", "[Tensor]") {
         size_t m = 8;
         Tensor a({n, m}, -4.0f, backend);
 
-        float norm = 4.0f * std::sqrt(n * m);
-        REQUIRE(a.norm() == Tensor(norm, backend));
-        REQUIRE(a.norm().getShape() == Tensor::Shape({1}));
-        
+        float targetNorm = 4.0f * std::sqrt(n * m);
+        REQUIRE(a.norm() == Tensor(targetNorm, backend));
 
         float sum = 0;
         for (size_t i = 0; i < n; i++) {
@@ -468,10 +467,9 @@ TEST_CASE("Frobenius norm of random tensor", "[Tensor]") {
     DYNAMIC_SECTION(getBackendString(backend)) {
         Tensor a({8, 9, 4, 3}, -4.0f, backend);
 
-        float norm = 4.0f * std::sqrt(8 * 9 * 4 * 3);
-        REQUIRE(a.norm() == Tensor(norm, backend));
-        REQUIRE(a.norm().getShape() == Tensor::Shape({1}));
-        
+        float targetNorm = 4.0f * std::sqrt(8 * 9 * 4 * 3);
+        REQUIRE(a.norm() == Tensor(targetNorm, backend));
+
 
         a.fillRand();
 
@@ -481,7 +479,7 @@ TEST_CASE("Frobenius norm of random tensor", "[Tensor]") {
             sum += e * e;
         }
         
-        // random tensor has a lot of noise
+        // random tensor has a lot of noise, so use relative error
         Tensor ratio = a.norm() / std::sqrt(sum);
         REQUIRE(ratio.toVector()[0] > 0.99);
         REQUIRE(ratio.toVector()[0] < 1.01);


### PR DESCRIPTION
## CUDA Backend Sync

Closes #47 

Syncing the CUDA backend to implement missing features. nvcc is not yet
configured in CI, so tests are run locally.


### Failing Tests

#### In-place operators
- [x] 4 - In-place addition operator
- [x] 5 - In-place subtraction operator
- [x] 6 - In-place multiplication operator
- [x] 7 - In-place division operator

#### Reductions
- [x] 8  - Tensor mean reduction
- [x] 9  - Tensor sum reduction
- [x] 10 - Tensor max reduction
- [x] 11 - Tensor min reduction
- [x] 12 - Tensor prod reduction
- [x] 13 - Tensor mean reduction by sum reduction
- [x] 14 - Tensor reduction with stride

#### Misc
- [x] 50 - Indexed scalar assignment with float

#### Norms
- [x] 51 - Verify frobenius norm return tensor
- [x] 52 - Frobenius norm of scalar
- [x] 53 - Frobenius norm of vector
- [x] 54 - Frobenius norm of matrix
- [x] 55 - Frobenius norm of random tensor

#### Views
- [x] 81 - In-place addition operator on view
- [x] 82 - In-place subtraction operator on view
- [x] 83 - In-place multiplication operator on view
- [x] 84 - In-place division operator on view