### PR TITLE
feat: matrix multiplication

### DIFF
--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -99,6 +99,8 @@ public:
 
 	Tensor norm() const;
 
+	Tensor matmul(const Tensor::View& rhs) const;
+
 	Tensor::View operator[](size_t idx) const;
 
 	Tensor::View subsample(std::vector<size_t> strides) const;

--- a/include/nforge/core/tensor_view.h
+++ b/include/nforge/core/tensor_view.h
@@ -55,6 +55,8 @@ public:
 
 	Tensor::View operator[](size_t idx) const;
 
+	Tensor matmul(const Tensor::View& rhs) const;
+
 	Tensor::View subsample(std::vector<size_t> strides) const;
 
 	bool operator==(const Tensor& rhs) const;

--- a/src/backend/cpu/tensor_impl_CPU.cpp
+++ b/src/backend/cpu/tensor_impl_CPU.cpp
@@ -336,6 +336,39 @@ std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::norm(const TensorLayout& layout) 
 	return std::unique_ptr<Tensor::Impl>(result);
 }
 
+std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::matmul(const TensorLayout& lhsLayout,
+                                                      const Tensor::Impl* rhsImpl,
+                                                      const TensorLayout& rhsLayout,
+                                                      const TensorLayout& outLayout, size_t batch,
+                                                      size_t m, size_t k, size_t p) const {
+	auto outShape = Tensor::Shape(outLayout);
+	auto* result = new Tensor::CPUImpl(outShape);
+
+	const auto* rhs = static_cast<const Tensor::CPUImpl*>(rhsImpl);
+
+	const float* a = dataPtr();
+	const float* b = rhs->dataPtr();
+	auto& c = result->m_data;
+
+	for (size_t bat = 0; bat < batch; bat++) {
+		for (size_t i = 0; i < m; i++) {
+			for (size_t j = 0; j < p; j++) {
+				float sum = 0.0f;
+				for (size_t kk = 0; kk < k; kk++) {
+					size_t lhsIdx = bat * (m * k) + i * k + kk;
+					size_t rhsIdx = bat * (k * p) + kk * p + j;
+					sum +=
+					    a[physicalOffset(lhsIdx, lhsLayout)] * b[physicalOffset(rhsIdx, rhsLayout)];
+				}
+				size_t outIdx = bat * (m * p) + i * p + j;
+				c[physicalOffset(outIdx, outLayout)] = sum;
+			}
+		}
+	}
+
+	return std::unique_ptr<Tensor::Impl>(result);
+}
+
 
 std::unique_ptr<Tensor::Impl> Tensor::CPUImpl::less(const TensorLayout& lhsLayout,
                                                     const Tensor::Impl* rhsImpl,

--- a/src/backend/cpu/tensor_impl_CPU.h
+++ b/src/backend/cpu/tensor_impl_CPU.h
@@ -82,6 +82,12 @@ public:
 	std::unique_ptr<Tensor::Impl> norm(const TensorLayout& layout) const override;
 
 
+	std::unique_ptr<Tensor::Impl> matmul(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl,
+	                                     const TensorLayout& rhsLayout,
+	                                     const TensorLayout& outLayout, size_t batch, size_t m,
+	                                     size_t k, size_t p) const override;
+
+
 	std::unique_ptr<Tensor::Impl> less(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl,
 	                                   const TensorLayout& rhsLayout,
 	                                   const TensorLayout& outLayout) const override;

--- a/src/backend/cuda/tensor_impl_CUDA.cu
+++ b/src/backend/cuda/tensor_impl_CUDA.cu
@@ -299,6 +299,15 @@ std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::norm(const TensorLayout& layout)
 }
 
 
+std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::matmul(const TensorLayout& lhsLayout,
+                                                       const Tensor::Impl* rhsImpl,
+                                                       const TensorLayout& rhsLayout,
+                                                       const TensorLayout& outLayout, size_t batch,
+                                                       size_t m, size_t k, size_t p) const {
+	throw std::runtime_error("matmul: CUDA backend not implemented yet");
+}
+
+
 std::unique_ptr<Tensor::Impl> Tensor::CUDAImpl::less(const TensorLayout& lhsLayout,
                                                      const Tensor::Impl* rhsImpl,
                                                      const TensorLayout& rhsLayout,

--- a/src/backend/cuda/tensor_impl_CUDA.h
+++ b/src/backend/cuda/tensor_impl_CUDA.h
@@ -80,6 +80,12 @@ public:
 	std::unique_ptr<Tensor::Impl> norm(const TensorLayout& layout) const override;
 
 
+	std::unique_ptr<Tensor::Impl> matmul(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl,
+	                                     const TensorLayout& rhsLayout,
+	                                     const TensorLayout& outLayout, size_t batch, size_t m,
+	                                     size_t k, size_t p) const override;
+
+
 	std::unique_ptr<Tensor::Impl> less(const TensorLayout& lhsLayout, const Tensor::Impl* rhsImpl,
 	                                   const TensorLayout& rhsLayout,
 	                                   const TensorLayout& outLayout) const override;

--- a/src/backend/tensor_impl.h
+++ b/src/backend/tensor_impl.h
@@ -86,6 +86,14 @@ public:
 
 	virtual std::unique_ptr<Tensor::Impl> norm(const TensorLayout& layout) const = 0;
 
+
+	virtual std::unique_ptr<Tensor::Impl> matmul(const TensorLayout& lhsLayout,
+	                                             const Tensor::Impl* rhsImpl,
+	                                             const TensorLayout& rhsLayout,
+	                                             const TensorLayout& outLayout, size_t batch,
+	                                             size_t m, size_t k, size_t p) const = 0;
+
+
 	virtual std::unique_ptr<Tensor::Impl> less(const TensorLayout& lhsLayout,
 	                                           const Tensor::Impl* rhsImpl,
 	                                           const TensorLayout& rhsLayout,

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -82,7 +82,7 @@ std::vector<float> Tensor::toVector() const { return m_impl->toVector(); }
 void Tensor::set(const std::vector<size_t>& position, const Tensor::View& rhs) {
 	Tensor::View lhs = Tensor::View((Tensor&)*this, position);
 
-	auto ctx = semantic::validateBinaryOperation(lhs, rhs);
+	auto ctx = semantic::BinaryOpContext::build(lhs, rhs);
 
 	auto outShape = Tensor::Shape(ctx.out);
 
@@ -98,7 +98,7 @@ bool Tensor::compare(const Tensor::View& rhs) const {
 		return false;
 	}
 
-	auto ctx = semantic::validateBinaryOperation(*this, rhs);
+	auto ctx = semantic::BinaryOpContext::build(*this, rhs);
 	return m_impl->compare(ctx.lhs, rhs.getParent().m_impl.get(), ctx.rhs);
 }
 
@@ -109,13 +109,13 @@ bool Tensor::compare(const std::vector<size_t>& position, const Tensor::View& rh
 		return false;
 	}
 
-	auto ctx = semantic::validateBinaryOperation(lhs, rhs);
+	auto ctx = semantic::BinaryOpContext::build(lhs, rhs);
 	return m_impl->compare(ctx.lhs, rhs.getParent().m_impl.get(), ctx.rhs);
 }
 
 template <typename BinaryOp>
 Tensor Tensor::applyBinaryOp(const Tensor::View& rhs, BinaryOp op) const {
-	auto ctx = semantic::validateBinaryOperation(*this, rhs);
+	auto ctx = semantic::BinaryOpContext::build(*this, rhs);
 
 	Tensor::Impl* rhsImpl = rhs.getParent().m_impl.get();
 	auto result = (m_impl.get()->*op)(ctx.lhs, rhsImpl, ctx.rhs, ctx.out);
@@ -157,7 +157,7 @@ Tensor operator/(float scalar, const Tensor& rhs) { return Tensor(scalar, rhs.m_
 
 template <typename BinaryOp>
 void Tensor::applyInplaceBinaryOp(const Tensor::View& rhs, BinaryOp op) {
-	auto ctx = semantic::validateInplaceBinaryOperation(*this, rhs);
+	auto ctx = semantic::InplaceBinaryOpContext::build(*this, rhs);
 
 	Tensor::Impl* rhsImpl = rhs.getParent().m_impl.get();
 
@@ -174,7 +174,7 @@ void Tensor::operator/=(const Tensor::View& rhs) { applyInplaceBinaryOp(rhs, &Te
 
 template <typename ReductionOp>
 Tensor Tensor::applyReduction(size_t dim, ReductionOp op) const {
-	auto ctx = semantic::validateReduction(*this, dim);
+	auto ctx = semantic::ReductionContext::build(*this, dim);
 
 	auto result = (m_impl.get()->*op)(ctx.lhs, ctx.block, ctx.out);
 
@@ -205,7 +205,7 @@ Tensor Tensor::norm() const {
 }
 
 Tensor Tensor::matmul(const Tensor::View& rhs) const {
-	auto ctx = semantic::validateMatmul(*this, rhs);
+	auto ctx = semantic::MatmulContext::build(*this, rhs);
 
 	Tensor::Impl* rhsImpl = rhs.getParent().m_impl.get();
 	auto result =
@@ -215,7 +215,7 @@ Tensor Tensor::matmul(const Tensor::View& rhs) const {
 }
 
 Tensor::View Tensor::operator[](size_t idx) const {
-	auto ctx = semantic::validateIndexing(*this, idx);
+	auto ctx = semantic::IndexContext::build(*this, idx);
 
 	std::vector<size_t> position = {idx};
 	Tensor& parent = const_cast<Tensor&>(*this);

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -204,6 +204,16 @@ Tensor Tensor::norm() const {
 	return Tensor(std::move(result), m_backend);
 }
 
+Tensor Tensor::matmul(const Tensor::View& rhs) const {
+	auto ctx = semantic::validateMatmul(*this, rhs);
+
+	Tensor::Impl* rhsImpl = rhs.getParent().m_impl.get();
+	auto result =
+	    m_impl->matmul(ctx.lhs, rhsImpl, ctx.rhs, ctx.out, ctx.batch, ctx.m, ctx.k, ctx.p);
+
+	return Tensor(std::move(result), m_backend);
+}
+
 Tensor::View Tensor::operator[](size_t idx) const {
 	auto ctx = semantic::validateIndexing(*this, idx);
 

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -194,6 +194,11 @@ Tensor::View Tensor::View::operator[](size_t idx) const {
 	return out;
 }
 
+Tensor Tensor::View::matmul(const Tensor::View& rhs) const {
+	Tensor current = copy();
+	return current.matmul(rhs);
+}
+
 Tensor::View Tensor::View::subsample(const Tensor::View& src, const std::vector<size_t>& factors) {
 	if (src.getShape().getNumDims() != factors.size()) {
 		throw std::runtime_error("Can't subsample view of shape" + src.getShape().toString() +

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -129,25 +129,25 @@ Tensor Tensor::View::operator/(const Tensor::View& rhs) const {
 }
 
 void Tensor::View::operator+=(const Tensor::View& rhs) {
-	auto ctx = semantic::validateInplaceBinaryOperation(*this, rhs);
+	auto ctx = semantic::InplaceBinaryOpContext::build(*this, rhs);
 
 	m_parent.m_impl->iadd(ctx.lhs, rhs.m_parent.m_impl.get(), ctx.rhs);
 }
 
 void Tensor::View::operator-=(const Tensor::View& rhs) {
-	auto ctx = semantic::validateInplaceBinaryOperation(*this, rhs);
+	auto ctx = semantic::InplaceBinaryOpContext::build(*this, rhs);
 
 	m_parent.m_impl->isub(ctx.lhs, rhs.m_parent.m_impl.get(), ctx.rhs);
 }
 
 void Tensor::View::operator*=(const Tensor::View& rhs) {
-	auto ctx = semantic::validateInplaceBinaryOperation(*this, rhs);
+	auto ctx = semantic::InplaceBinaryOpContext::build(*this, rhs);
 
 	m_parent.m_impl->imul(ctx.lhs, rhs.m_parent.m_impl.get(), ctx.rhs);
 }
 
 void Tensor::View::operator/=(const Tensor::View& rhs) {
-	auto ctx = semantic::validateInplaceBinaryOperation(*this, rhs);
+	auto ctx = semantic::InplaceBinaryOpContext::build(*this, rhs);
 
 	m_parent.m_impl->idiv(ctx.lhs, rhs.m_parent.m_impl.get(), ctx.rhs);
 }
@@ -155,7 +155,7 @@ void Tensor::View::operator/=(const Tensor::View& rhs) {
 Tensor::View Tensor::View::operator=(const Tensor& rhs) {
 	Tensor::View rhsView(rhs);
 
-	auto ctx = semantic::validateBinaryOperation(*this, rhsView);
+	auto ctx = semantic::BinaryOpContext::build(*this, rhsView);
 	if (Tensor::Shape(ctx.out) != getShape()) {
 		throw std::invalid_argument("set(): rhs shape does not broadcast to target shape");
 	}
@@ -165,7 +165,7 @@ Tensor::View Tensor::View::operator=(const Tensor& rhs) {
 }
 
 Tensor::View Tensor::View::operator=(const Tensor::View& rhs) {
-	auto ctx = semantic::validateBinaryOperation(*this, rhs);
+	auto ctx = semantic::BinaryOpContext::build(*this, rhs);
 	if (Tensor::Shape(ctx.out) != getShape()) {
 		throw std::invalid_argument("set(): rhs shape does not broadcast to target shape");
 	}
@@ -185,7 +185,7 @@ Tensor::View Tensor::View::operator=(float scalar) {
 }
 
 Tensor::View Tensor::View::operator[](size_t idx) const {
-	auto ctx = semantic::validateIndexing(*this, idx);
+	auto ctx = semantic::IndexContext::build(*this, idx);
 
 	std::vector<size_t> position = m_position;
 	position.push_back(idx);
@@ -247,14 +247,14 @@ bool Tensor::View::operator==(const Tensor& rhs) const {
 	Tensor::View rhsView(rhs);
 	if (getShape() != rhsView.getShape())
 		return false;
-	auto ctx = semantic::validateBinaryOperation(*this, rhsView);
+	auto ctx = semantic::BinaryOpContext::build(*this, rhsView);
 	return m_parent.m_impl->compare(ctx.lhs, rhs.m_impl.get(), ctx.rhs);
 }
 
 bool Tensor::View::operator==(const Tensor::View& rhs) const {
 	if (getShape() != rhs.getShape())
 		return false;
-	auto ctx = semantic::validateBinaryOperation(*this, rhs);
+	auto ctx = semantic::BinaryOpContext::build(*this, rhs);
 	return m_parent.m_impl->compare(ctx.lhs, rhs.m_parent.m_impl.get(), ctx.rhs);
 }
 

--- a/src/ops/matmul/matmul.cpp
+++ b/src/ops/matmul/matmul.cpp
@@ -1,0 +1,3 @@
+#include "ops/matmul/matmul.h"
+
+Tensor nforge::matmul(const Tensor::View& lhs, const Tensor::View& rhs) { return lhs.matmul(rhs); }

--- a/src/ops/matmul/matmul.h
+++ b/src/ops/matmul/matmul.h
@@ -1,0 +1,13 @@
+#ifndef NFORGE_OPS_MATMUL_H
+#define NFORGE_OPS_MATMUL_H
+
+#include "nforge/core/tensor.h"
+#include "nforge/core/tensor_view.h"
+
+namespace nforge {
+
+Tensor matmul(const Tensor::View& lhs, const Tensor::View& rhs);
+
+};  // namespace nforge
+
+#endif  // NFORGE_OPS_MATMUL_H

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -110,49 +110,28 @@ IndexContext IndexContext::build(const Tensor::View& src, size_t idx) {
 
 	TensorLayout out(shape, strides, offset);
 
-	return IndexContext{out};
-}
-
-MatmulContext MatmulContext::build(const Tensor::View& lhs, const Tensor::View& rhs) {
-	ensureSameBackend(lhs, rhs);
-
-	Tensor::Shape lhsShape = lhs.getShape();
-	Tensor::Shape rhsShape = rhs.getShape();
-	size_t lhsRank = lhsShape.getNumDims();
-	size_t rhsRank = rhsShape.getNumDims();
-
-	validateRanks(lhsRank, rhsRank);
-	validateInnerDims(lhsShape, rhsShape, lhsRank, rhsRank);
-
-	MatmulContext ctx;
-	ctx.m = lhsShape.getDim(lhsRank - 2);
-	ctx.k = lhsShape.getDim(lhsRank - 1);
-	ctx.p = rhsShape.getDim(rhsRank - 1);
-	ctx.batch = computeBatch(lhsShape, rhsShape, lhsRank, rhsRank);
-
-	ctx.lhs = lhs.getLayout();
-	ctx.rhs = rhs.getLayout();
-	ctx.out = computeOutputLayout(ctx.batch, ctx.m, ctx.p);
-
+	IndexContext ctx;
+	ctx.out = out;
 	return ctx;
 }
 
-void MatmulContext::validateRanks(size_t lhsRank, size_t rhsRank) {
+
+void validateRanksMatmul(size_t lhsRank, size_t rhsRank) {
 	if (lhsRank < 2 || lhsRank > 3 || rhsRank < 2 || rhsRank > 3) {
 		throw std::runtime_error("matmul: inputs must be 2D or 3D tensors");
 	}
 }
 
-void MatmulContext::validateInnerDims(const Tensor::Shape& lhsShape, const Tensor::Shape& rhsShape,
-                                      size_t lhsRank, size_t rhsRank) {
+void validateInnerDimsMatmul(const Tensor::Shape& lhsShape, const Tensor::Shape& rhsShape,
+                             size_t lhsRank, size_t rhsRank) {
 	if (lhsShape.getDim(lhsRank - 1) != rhsShape.getDim(rhsRank - 2)) {
 		throw std::runtime_error("matmul: inner dimensions must match, got " + lhsShape.toString() +
 		                         " and " + rhsShape.toString());
 	}
 }
 
-size_t MatmulContext::computeBatch(const Tensor::Shape& lhsShape, const Tensor::Shape& rhsShape,
-                                   size_t lhsRank, size_t rhsRank) {
+size_t computeBatchMatmul(const Tensor::Shape& lhsShape, const Tensor::Shape& rhsShape,
+                          size_t lhsRank, size_t rhsRank) {
 	const size_t lhsBatch = (lhsRank == 3) ? lhsShape.getDim(0) : 1;
 	const size_t rhsBatch = (rhsRank == 3) ? rhsShape.getDim(0) : 1;
 
@@ -163,7 +142,7 @@ size_t MatmulContext::computeBatch(const Tensor::Shape& lhsShape, const Tensor::
 	return std::max(lhsBatch, rhsBatch);
 }
 
-TensorLayout MatmulContext::computeOutputLayout(size_t batch, size_t m, size_t p) {
+TensorLayout computeOutputLayoutMatmul(size_t batch, size_t m, size_t p) {
 	std::vector<size_t> outDims;
 	if (batch > 1) {
 		outDims.push_back(batch);
@@ -172,6 +151,31 @@ TensorLayout MatmulContext::computeOutputLayout(size_t batch, size_t m, size_t p
 	outDims.push_back(p);
 
 	return Tensor::Shape(outDims).toContiguousLayout();
+}
+
+
+MatmulContext MatmulContext::build(const Tensor::View& lhs, const Tensor::View& rhs) {
+	ensureSameBackend(lhs, rhs);
+
+	Tensor::Shape lhsShape = lhs.getShape();
+	Tensor::Shape rhsShape = rhs.getShape();
+	size_t lhsRank = lhsShape.getNumDims();
+	size_t rhsRank = rhsShape.getNumDims();
+
+	validateRanksMatmul(lhsRank, rhsRank);
+	validateInnerDimsMatmul(lhsShape, rhsShape, lhsRank, rhsRank);
+
+	MatmulContext ctx;
+	ctx.m = lhsShape.getDim(lhsRank - 2);
+	ctx.k = lhsShape.getDim(lhsRank - 1);
+	ctx.p = rhsShape.getDim(rhsRank - 1);
+	ctx.batch = computeBatchMatmul(lhsShape, rhsShape, lhsRank, rhsRank);
+
+	ctx.lhs = lhs.getLayout();
+	ctx.rhs = rhs.getLayout();
+	ctx.out = computeOutputLayoutMatmul(ctx.batch, ctx.m, ctx.p);
+
+	return ctx;
 }
 
 

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -107,6 +107,41 @@ IndexContext buildIndexContext(const Tensor::View& src, size_t idx) {
 	return res;
 }
 
+MatmulContext buildMatmulContext(const Tensor::View& lhs, const Tensor::View& rhs) {
+	Tensor::Shape lhsShape = lhs.getShape();
+	Tensor::Shape rhsShape = rhs.getShape();
+
+	size_t lhsRank = lhsShape.getNumDims();
+	size_t rhsRank = rhsShape.getNumDims();
+
+	size_t m = lhsShape.getDim(lhsRank - 2);
+	size_t k = lhsShape.getDim(lhsRank - 1);
+	size_t p = rhsShape.getDim(rhsRank - 1);
+
+	size_t lhsBatch = (lhsRank == 3) ? lhsShape.getDim(0) : 1;
+	size_t rhsBatch = (rhsRank == 3) ? rhsShape.getDim(0) : 1;
+	size_t batch = std::max(lhsBatch, rhsBatch);
+
+	std::vector<size_t> outDims;
+	if (batch > 1)
+		outDims.push_back(batch);
+	outDims.push_back(m);
+	outDims.push_back(p);
+
+	Tensor::Shape outShape(outDims);
+
+	MatmulContext ctx;
+	ctx.lhs = layoutFromView(lhs);
+	ctx.rhs = layoutFromView(rhs);
+	ctx.out = outShape.toContiguousLayout();
+	ctx.batch = batch;
+	ctx.m = m;
+	ctx.k = k;
+	ctx.p = p;
+	return ctx;
+}
+
+
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs) {
 	ensureSameBackend(lhs.getParent(), rhs.getParent());
 
@@ -147,6 +182,39 @@ IndexContext validateIndexing(const Tensor::View& src, size_t idx) {
 	}
 
 	return buildIndexContext(src, idx);
+}
+
+
+MatmulContext validateMatmul(const Tensor::View& lhs, const Tensor::View& rhs) {
+	ensureSameBackend(lhs.getParent(), rhs.getParent());
+
+	Tensor::Shape lhsShape = lhs.getShape();
+	Tensor::Shape rhsShape = rhs.getShape();
+
+	size_t lhsRank = lhsShape.getNumDims();
+	size_t rhsRank = rhsShape.getNumDims();
+
+	if (lhsRank < 2 || lhsRank > 3 || rhsRank < 2 || rhsRank > 3) {
+		throw std::runtime_error("matmul: inputs must be 2D or 3D tensors");
+	}
+
+	size_t k_lhs = lhsShape.getDim(lhsRank - 1);
+	size_t k_rhs = rhsShape.getDim(rhsRank - 2);
+	if (k_lhs != k_rhs) {
+		throw std::runtime_error("matmul: inner dimensions must match, got " + lhsShape.toString() +
+		                         " and " + rhsShape.toString());
+	}
+
+	if (lhsRank == 3 && rhsRank == 3) {
+		size_t lhsBatch = lhsShape.getDim(0);
+		size_t rhsBatch = rhsShape.getDim(0);
+		if (lhsBatch != rhsBatch && lhsBatch != 1 && rhsBatch != 1) {
+			throw std::runtime_error("matmul: batch dimensions must match or be 1, got " +
+			                         lhsShape.toString() + " and " + rhsShape.toString());
+		}
+	}
+
+	return buildMatmulContext(lhs, rhs);
 }
 
 }  // namespace semantic

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -64,7 +64,9 @@ static TensorLayout broadcastTo(TensorLayout src, const Tensor::Shape& target) {
 	return dst;
 }
 
-BinaryOpContext buildBinaryOpContext(const Tensor::View& lhs, const Tensor::View& rhs) {
+BinaryOpContext BinaryOpContext::build(const Tensor::View& lhs, const Tensor::View& rhs) {
+	ensureSameBackend(lhs.getParent(), rhs.getParent());
+
 	Tensor::Shape outShape = broadcastShapes(lhs.getShape(), rhs.getShape());
 
 	BinaryOpContext ctx;
@@ -74,14 +76,12 @@ BinaryOpContext buildBinaryOpContext(const Tensor::View& lhs, const Tensor::View
 	return ctx;
 }
 
-BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs) {
-	ensureSameBackend(lhs.getParent(), rhs.getParent());
+ReductionContext ReductionContext::build(const Tensor::View& lhs, size_t dim) {
+	if (dim > lhs.getShape().getNumDims()) {
+		throw std::runtime_error("Can not reduce Tensor of shape " + lhs.getShape().toString() +
+		                         " with along dim " + std::to_string(dim));
+	}
 
-	return buildBinaryOpContext(lhs, rhs);
-}
-
-
-ReductionContext buildReductionContext(const Tensor::View& lhs, size_t dim) {
 	Tensor::Shape lhsShape = lhs.getShape();
 
 	Tensor::Shape blockShape = lhsShape.getSlice(dim, lhsShape.getNumDims());
@@ -94,17 +94,13 @@ ReductionContext buildReductionContext(const Tensor::View& lhs, size_t dim) {
 	return ctx;
 }
 
-ReductionContext validateReduction(const Tensor::View& lhs, size_t dim) {
-	if (dim > lhs.getShape().getNumDims()) {
-		throw std::runtime_error("Can not reduce Tensor of shape " + lhs.getShape().toString() +
-		                         " with along dim " + std::to_string(dim));
+IndexContext IndexContext::build(const Tensor::View& src, size_t idx) {
+	Tensor::Shape srcShape = src.getShape();
+	if (idx < 0 || idx >= srcShape.getDim(0)) {
+		throw std::out_of_range("Index " + std::to_string(idx) +
+		                        " is out of bounds. Tensor view shape: " + srcShape.toString());
 	}
 
-	return buildReductionContext(lhs, dim);
-}
-
-
-IndexContext buildIndexContext(const Tensor::View& src, size_t idx) {
 	TensorLayout layout = src.getLayout();
 	size_t offset = layout.offset + layout.strides[0] * idx;
 	auto shape = Tensor::Shape(layout)[0];
@@ -124,23 +120,33 @@ IndexContext buildIndexContext(const Tensor::View& src, size_t idx) {
 	return res;
 }
 
-IndexContext validateIndexing(const Tensor::View& src, size_t idx) {
-	Tensor::Shape shape = src.getShape();
-	if (idx < 0 || idx >= shape.getDim(0)) {
-		throw std::out_of_range("Index " + std::to_string(idx) +
-		                        " is out of bounds. Tensor view shape: " + shape.toString());
-	}
+MatmulContext MatmulContext::build(const Tensor::View& lhs, const Tensor::View& rhs) {
+	ensureSameBackend(lhs.getParent(), rhs.getParent());
 
-	return buildIndexContext(src, idx);
-}
-
-
-MatmulContext buildMatmulContext(const Tensor::View& lhs, const Tensor::View& rhs) {
 	Tensor::Shape lhsShape = lhs.getShape();
 	Tensor::Shape rhsShape = rhs.getShape();
-
 	size_t lhsRank = lhsShape.getNumDims();
 	size_t rhsRank = rhsShape.getNumDims();
+
+	if (lhsRank < 2 || lhsRank > 3 || rhsRank < 2 || rhsRank > 3) {
+		throw std::runtime_error("matmul: inputs must be 2D or 3D tensors");
+	}
+
+	size_t k_lhs = lhsShape.getDim(lhsRank - 1);
+	size_t k_rhs = rhsShape.getDim(rhsRank - 2);
+	if (k_lhs != k_rhs) {
+		throw std::runtime_error("matmul: inner dimensions must match, got " + lhsShape.toString() +
+		                         " and " + rhsShape.toString());
+	}
+
+	if (lhsRank == 3 && rhsRank == 3) {
+		size_t lhsBatch = lhsShape.getDim(0);
+		size_t rhsBatch = rhsShape.getDim(0);
+		if (lhsBatch != rhsBatch && lhsBatch != 1 && rhsBatch != 1) {
+			throw std::runtime_error("matmul: batch dimensions must match or be 1, got " +
+			                         lhsShape.toString() + " and " + rhsShape.toString());
+		}
+	}
 
 	size_t m = lhsShape.getDim(lhsRank - 2);
 	size_t k = lhsShape.getDim(lhsRank - 1);
@@ -169,42 +175,10 @@ MatmulContext buildMatmulContext(const Tensor::View& lhs, const Tensor::View& rh
 	return ctx;
 }
 
-MatmulContext validateMatmul(const Tensor::View& lhs, const Tensor::View& rhs) {
-	ensureSameBackend(lhs.getParent(), rhs.getParent());
 
-	Tensor::Shape lhsShape = lhs.getShape();
-	Tensor::Shape rhsShape = rhs.getShape();
-
-	size_t lhsRank = lhsShape.getNumDims();
-	size_t rhsRank = rhsShape.getNumDims();
-
-	if (lhsRank < 2 || lhsRank > 3 || rhsRank < 2 || rhsRank > 3) {
-		throw std::runtime_error("matmul: inputs must be 2D or 3D tensors");
-	}
-
-	size_t k_lhs = lhsShape.getDim(lhsRank - 1);
-	size_t k_rhs = rhsShape.getDim(rhsRank - 2);
-	if (k_lhs != k_rhs) {
-		throw std::runtime_error("matmul: inner dimensions must match, got " + lhsShape.toString() +
-		                         " and " + rhsShape.toString());
-	}
-
-	if (lhsRank == 3 && rhsRank == 3) {
-		size_t lhsBatch = lhsShape.getDim(0);
-		size_t rhsBatch = rhsShape.getDim(0);
-		if (lhsBatch != rhsBatch && lhsBatch != 1 && rhsBatch != 1) {
-			throw std::runtime_error("matmul: batch dimensions must match or be 1, got " +
-			                         lhsShape.toString() + " and " + rhsShape.toString());
-		}
-	}
-
-	return buildMatmulContext(lhs, rhs);
-}
-
-
-InplaceBinaryOpContext validateInplaceBinaryOperation(const Tensor::View& lhs,
-                                                      const Tensor::View& rhs) {
-	BinaryOpContext ctx = validateBinaryOperation(lhs, rhs);
+InplaceBinaryOpContext InplaceBinaryOpContext::build(const Tensor::View& lhs,
+                                                     const Tensor::View& rhs) {
+	BinaryOpContext ctx = BinaryOpContext::build(lhs, rhs);
 	const TensorLayout& lhsLayout = lhs.getLayout();
 
 	if (lhsLayout != ctx.lhs) {

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -19,31 +19,31 @@ void ensureSameBackend(const Tensor::View& lhs, const Tensor::View& rhs) {
 	}
 }
 
-static TensorLayout layoutFromView(const Tensor::View& v) { return v.getLayout(); }
+TensorLayout layoutFromView(const Tensor::View& v) { return v.getLayout(); }
 
-Tensor::Shape broadcastShapes(const Tensor::Shape& a, const Tensor::Shape& b) {
-	const size_t rankA = a.getNumDims();
-	const size_t rankB = b.getNumDims();
-	const size_t rankOut = std::max(rankA, rankB);
+Tensor::Shape broadcastShapes(const Tensor::Shape& lhs, const Tensor::Shape& rhs) {
+	const size_t rankLhs = lhs.getNumDims();
+	const size_t rankRhs = rhs.getNumDims();
+	const size_t rankOut = std::max(rankLhs, rankRhs);
 
 	std::vector<size_t> out(rankOut);
 
 	// a dimension of size 1 can be broadcasted
 	for (size_t i = 0; i < rankOut; ++i) {
 		// one if dim does not exist
-		const size_t dimA = (i < rankA) ? a.getDim(rankA - 1 - i) : 1;
-		const size_t dimB = (i < rankB) ? b.getDim(rankB - 1 - i) : 1;
+		const size_t dimLhs = (i < rankLhs) ? lhs.getDim(rankLhs - 1 - i) : 1;
+		const size_t dimRhs = (i < rankRhs) ? rhs.getDim(rankRhs - 1 - i) : 1;
 
 		size_t dim;
-		if (dimA == dimB) {
-			dim = dimA;
-		} else if (dimA == 1) {
-			dim = dimB;
-		} else if (dimB == 1) {
-			dim = dimA;
+		if (dimLhs == dimRhs) {
+			dim = dimLhs;
+		} else if (dimLhs == 1) {
+			dim = dimRhs;
+		} else if (dimRhs == 1) {
+			dim = dimLhs;
 		} else {
-			throw std::runtime_error("Cannot broadcast shapes " + a.toString() + " and " +
-			                         b.toString());
+			throw std::runtime_error("Cannot broadcast shapes " + lhs.toString() + " and " +
+			                         rhs.toString());
 		}
 
 		out[rankOut - 1 - i] = dim;
@@ -52,24 +52,22 @@ Tensor::Shape broadcastShapes(const Tensor::Shape& a, const Tensor::Shape& b) {
 	return Tensor::Shape(out);
 }
 
-static TensorLayout broadcastTo(TensorLayout src, const Tensor::Shape& target) {
-	TensorLayout dst{};
-	dst.rank = target.getNumDims();
-	dst.offset = src.offset;
+TensorLayout broadcastTo(TensorLayout src, const Tensor::Shape& target) {
+	std::vector<size_t> strides(target.getNumDims());
 
-	int pad = (int)dst.rank - (int)src.rank;  // align right
-	for (int d = 0; d < dst.rank; d++) {
-		dst.shape[d] = target.getDim(d);
+	int pad = (int)target.getNumDims() - (int)src.rank;  // align right
 
+	for (int d = 0; d < target.getNumDims(); d++) {
 		int sd = d - pad;
 
 		if (sd < 0 || src.shape[sd] == 1) {
-			dst.strides[d] = 0;
+			strides[d] = 0;
 		} else {
-			dst.strides[d] = src.strides[sd];
+			strides[d] = src.strides[sd];
 		}
 	}
-	return dst;
+
+	return TensorLayout(target, strides, src.offset);
 }
 
 BinaryOpContext BinaryOpContext::build(const Tensor::View& lhs, const Tensor::View& rhs) {

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -128,51 +128,57 @@ MatmulContext MatmulContext::build(const Tensor::View& lhs, const Tensor::View& 
 	size_t lhsRank = lhsShape.getNumDims();
 	size_t rhsRank = rhsShape.getNumDims();
 
+	validateRanks(lhsRank, rhsRank);
+	validateInnerDims(lhsShape, rhsShape, lhsRank, rhsRank);
+
+	MatmulContext ctx;
+	ctx.m = lhsShape.getDim(lhsRank - 2);
+	ctx.k = lhsShape.getDim(lhsRank - 1);
+	ctx.p = rhsShape.getDim(rhsRank - 1);
+	ctx.batch = computeBatch(lhsShape, rhsShape, lhsRank, rhsRank);
+
+	ctx.lhs = layoutFromView(lhs);
+	ctx.rhs = layoutFromView(rhs);
+	ctx.out = computeOutputLayout(ctx.batch, ctx.m, ctx.p);
+
+	return ctx;
+}
+
+void MatmulContext::validateRanks(size_t lhsRank, size_t rhsRank) {
 	if (lhsRank < 2 || lhsRank > 3 || rhsRank < 2 || rhsRank > 3) {
 		throw std::runtime_error("matmul: inputs must be 2D or 3D tensors");
 	}
+}
 
-	size_t k_lhs = lhsShape.getDim(lhsRank - 1);
-	size_t k_rhs = rhsShape.getDim(rhsRank - 2);
-	if (k_lhs != k_rhs) {
+void MatmulContext::validateInnerDims(const Tensor::Shape& lhsShape, const Tensor::Shape& rhsShape,
+                                      size_t lhsRank, size_t rhsRank) {
+	if (lhsShape.getDim(lhsRank - 1) != rhsShape.getDim(rhsRank - 2)) {
 		throw std::runtime_error("matmul: inner dimensions must match, got " + lhsShape.toString() +
 		                         " and " + rhsShape.toString());
 	}
+}
 
-	if (lhsRank == 3 && rhsRank == 3) {
-		size_t lhsBatch = lhsShape.getDim(0);
-		size_t rhsBatch = rhsShape.getDim(0);
-		if (lhsBatch != rhsBatch && lhsBatch != 1 && rhsBatch != 1) {
-			throw std::runtime_error("matmul: batch dimensions must match or be 1, got " +
-			                         lhsShape.toString() + " and " + rhsShape.toString());
-		}
+size_t MatmulContext::computeBatch(const Tensor::Shape& lhsShape, const Tensor::Shape& rhsShape,
+                                   size_t lhsRank, size_t rhsRank) {
+	const size_t lhsBatch = (lhsRank == 3) ? lhsShape.getDim(0) : 1;
+	const size_t rhsBatch = (rhsRank == 3) ? rhsShape.getDim(0) : 1;
+
+	if (lhsRank == 3 && rhsRank == 3 && lhsBatch != rhsBatch && lhsBatch != 1 && rhsBatch != 1) {
+		throw std::runtime_error("matmul: batch dimensions must match or be 1, got " +
+		                         lhsShape.toString() + " and " + rhsShape.toString());
 	}
+	return std::max(lhsBatch, rhsBatch);
+}
 
-	size_t m = lhsShape.getDim(lhsRank - 2);
-	size_t k = lhsShape.getDim(lhsRank - 1);
-	size_t p = rhsShape.getDim(rhsRank - 1);
-
-	size_t lhsBatch = (lhsRank == 3) ? lhsShape.getDim(0) : 1;
-	size_t rhsBatch = (rhsRank == 3) ? rhsShape.getDim(0) : 1;
-	size_t batch = std::max(lhsBatch, rhsBatch);
-
+TensorLayout MatmulContext::computeOutputLayout(size_t batch, size_t m, size_t p) {
 	std::vector<size_t> outDims;
-	if (batch > 1)
+	if (batch > 1) {
 		outDims.push_back(batch);
+	}
 	outDims.push_back(m);
 	outDims.push_back(p);
 
-	Tensor::Shape outShape(outDims);
-
-	MatmulContext ctx;
-	ctx.lhs = layoutFromView(lhs);
-	ctx.rhs = layoutFromView(rhs);
-	ctx.out = outShape.toContiguousLayout();
-	ctx.batch = batch;
-	ctx.m = m;
-	ctx.k = k;
-	ctx.p = p;
-	return ctx;
+	return Tensor::Shape(outDims).toContiguousLayout();
 }
 
 

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -22,48 +22,39 @@ void ensureSameBackend(const Tensor::View& lhs, const Tensor::View& rhs) {
 TensorLayout layoutFromView(const Tensor::View& v) { return v.getLayout(); }
 
 Tensor::Shape broadcastShapes(const Tensor::Shape& lhs, const Tensor::Shape& rhs) {
-	const size_t rankLhs = lhs.getNumDims();
-	const size_t rankRhs = rhs.getNumDims();
-	const size_t rankOut = std::max(rankLhs, rankRhs);
+	size_t rankLhs = lhs.getNumDims();
+	size_t rankRhs = rhs.getNumDims();
+	size_t rankOut = std::max(rankLhs, rankRhs);
 
-	std::vector<size_t> out(rankOut);
+	std::vector<size_t> outDims(rankOut);
 
-	// a dimension of size 1 can be broadcasted
-	for (size_t i = 0; i < rankOut; ++i) {
-		// one if dim does not exist
-		const size_t dimLhs = (i < rankLhs) ? lhs.getDim(rankLhs - 1 - i) : 1;
-		const size_t dimRhs = (i < rankRhs) ? rhs.getDim(rankRhs - 1 - i) : 1;
+	for (size_t i = 1; i <= rankOut; i++) {
+		// pad with 1s
+		size_t dimLhs = (i <= rankLhs) ? lhs.getDim(rankLhs - i) : 1;
+		size_t dimRhs = (i <= rankRhs) ? rhs.getDim(rankRhs - i) : 1;
 
-		size_t dim;
-		if (dimLhs == dimRhs) {
-			dim = dimLhs;
-		} else if (dimLhs == 1) {
-			dim = dimRhs;
-		} else if (dimRhs == 1) {
-			dim = dimLhs;
-		} else {
-			throw std::runtime_error("Cannot broadcast shapes " + lhs.toString() + " and " +
+		// dimensions must match or be 1 to broadcast
+		if (dimLhs != dimRhs && dimLhs != 1 && dimRhs != 1) {
+			throw std::runtime_error("Can not broadcast shapes " + lhs.toString() + " and " +
 			                         rhs.toString());
 		}
 
-		out[rankOut - 1 - i] = dim;
+		// output is the non 1 dimension or 1 if both are 1
+		outDims[rankOut - i] = (dimLhs == 1) ? dimRhs : dimLhs;
 	}
 
-	return Tensor::Shape(out);
+	return Tensor::Shape(outDims);
 }
 
 TensorLayout broadcastTo(TensorLayout src, const Tensor::Shape& target) {
-	std::vector<size_t> strides(target.getNumDims());
+	size_t targetRank = target.getNumDims();
+	std::vector<size_t> strides(targetRank, 0);
 
-	int pad = (int)target.getNumDims() - (int)src.rank;  // align right
-
-	for (int d = 0; d < target.getNumDims(); d++) {
-		int sd = d - pad;
-
-		if (sd < 0 || src.shape[sd] == 1) {
-			strides[d] = 0;
-		} else {
-			strides[d] = src.strides[sd];
+	int pad = (int)targetRank - (int)src.rank;  // align right
+	for (int d = pad; d < targetRank; d++) {
+		// use stride if dim is not size 1
+		if (src.shape[d - pad] != 1) {
+			strides[d] = src.strides[d - pad];
 		}
 	}
 
@@ -89,9 +80,8 @@ ReductionContext ReductionContext::build(const Tensor::View& lhs, size_t dim) {
 	}
 
 	Tensor::Shape lhsShape = lhs.getShape();
-
-	Tensor::Shape blockShape = lhsShape.getSlice(dim, lhsShape.getNumDims());
 	Tensor::Shape outShape = lhsShape.getSlice(0, dim);
+	Tensor::Shape blockShape = lhsShape.getSlice(dim, lhsShape.getNumDims());
 
 	ReductionContext ctx;
 	ctx.lhs = lhsShape;
@@ -122,8 +112,7 @@ IndexContext IndexContext::build(const Tensor::View& src, size_t idx) {
 
 	TensorLayout out(shape, strides, offset);
 
-	IndexContext res{out};
-	return res;
+	return IndexContext{out};
 }
 
 MatmulContext MatmulContext::build(const Tensor::View& lhs, const Tensor::View& rhs) {

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -64,7 +64,7 @@ static TensorLayout broadcastTo(TensorLayout src, const Tensor::Shape& target) {
 	return dst;
 }
 
-BinaryOpContext buildContext(const Tensor::View& lhs, const Tensor::View& rhs) {
+BinaryOpContext buildBinaryOpContext(const Tensor::View& lhs, const Tensor::View& rhs) {
 	Tensor::Shape outShape = broadcastShapes(lhs.getShape(), rhs.getShape());
 
 	BinaryOpContext ctx;
@@ -73,6 +73,13 @@ BinaryOpContext buildContext(const Tensor::View& lhs, const Tensor::View& rhs) {
 	ctx.out = outShape.toContiguousLayout();
 	return ctx;
 }
+
+BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs) {
+	ensureSameBackend(lhs.getParent(), rhs.getParent());
+
+	return buildBinaryOpContext(lhs, rhs);
+}
+
 
 ReductionContext buildReductionContext(const Tensor::View& lhs, size_t dim) {
 	Tensor::Shape lhsShape = lhs.getShape();
@@ -86,6 +93,16 @@ ReductionContext buildReductionContext(const Tensor::View& lhs, size_t dim) {
 	ctx.block = blockShape;
 	return ctx;
 }
+
+ReductionContext validateReduction(const Tensor::View& lhs, size_t dim) {
+	if (dim > lhs.getShape().getNumDims()) {
+		throw std::runtime_error("Can not reduce Tensor of shape " + lhs.getShape().toString() +
+		                         " with along dim " + std::to_string(dim));
+	}
+
+	return buildReductionContext(lhs, dim);
+}
+
 
 IndexContext buildIndexContext(const Tensor::View& src, size_t idx) {
 	TensorLayout layout = src.getLayout();
@@ -106,6 +123,17 @@ IndexContext buildIndexContext(const Tensor::View& src, size_t idx) {
 	IndexContext res{out};
 	return res;
 }
+
+IndexContext validateIndexing(const Tensor::View& src, size_t idx) {
+	Tensor::Shape shape = src.getShape();
+	if (idx < 0 || idx >= shape.getDim(0)) {
+		throw std::out_of_range("Index " + std::to_string(idx) +
+		                        " is out of bounds. Tensor view shape: " + shape.toString());
+	}
+
+	return buildIndexContext(src, idx);
+}
+
 
 MatmulContext buildMatmulContext(const Tensor::View& lhs, const Tensor::View& rhs) {
 	Tensor::Shape lhsShape = lhs.getShape();
@@ -141,50 +169,6 @@ MatmulContext buildMatmulContext(const Tensor::View& lhs, const Tensor::View& rh
 	return ctx;
 }
 
-
-BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs) {
-	ensureSameBackend(lhs.getParent(), rhs.getParent());
-
-	return buildContext(lhs, rhs);
-}
-
-InplaceBinaryOpContext validateInplaceBinaryOperation(const Tensor::View& lhs,
-                                                      const Tensor::View& rhs) {
-	BinaryOpContext ctx = validateBinaryOperation(lhs, rhs);
-	const TensorLayout& lhsLayout = lhs.getLayout();
-
-	if (lhsLayout != ctx.lhs) {
-		throw std::runtime_error(
-		    "Can not apply in-place operator where infered output is different from lhs!");
-	}
-
-	InplaceBinaryOpContext res;
-	res.lhs = ctx.lhs;
-	res.rhs = ctx.rhs;
-
-	return res;
-}
-
-ReductionContext validateReduction(const Tensor::View& lhs, size_t dim) {
-	if (dim > lhs.getShape().getNumDims()) {
-		throw std::runtime_error("Can not reduce Tensor of shape " + lhs.getShape().toString() +
-		                         " with along dim " + std::to_string(dim));
-	}
-
-	return buildReductionContext(lhs, dim);
-}
-
-IndexContext validateIndexing(const Tensor::View& src, size_t idx) {
-	Tensor::Shape shape = src.getShape();
-	if (idx < 0 || idx >= shape.getDim(0)) {
-		throw std::out_of_range("Index " + std::to_string(idx) +
-		                        " is out of bounds. Tensor view shape: " + shape.toString());
-	}
-
-	return buildIndexContext(src, idx);
-}
-
-
 MatmulContext validateMatmul(const Tensor::View& lhs, const Tensor::View& rhs) {
 	ensureSameBackend(lhs.getParent(), rhs.getParent());
 
@@ -216,5 +200,24 @@ MatmulContext validateMatmul(const Tensor::View& lhs, const Tensor::View& rhs) {
 
 	return buildMatmulContext(lhs, rhs);
 }
+
+
+InplaceBinaryOpContext validateInplaceBinaryOperation(const Tensor::View& lhs,
+                                                      const Tensor::View& rhs) {
+	BinaryOpContext ctx = validateBinaryOperation(lhs, rhs);
+	const TensorLayout& lhsLayout = lhs.getLayout();
+
+	if (lhsLayout != ctx.lhs) {
+		throw std::runtime_error(
+		    "Can not apply in-place operator where infered output is different from lhs!");
+	}
+
+	InplaceBinaryOpContext res;
+	res.lhs = ctx.lhs;
+	res.rhs = ctx.rhs;
+
+	return res;
+}
+
 
 }  // namespace semantic

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -19,8 +19,6 @@ void ensureSameBackend(const Tensor::View& lhs, const Tensor::View& rhs) {
 	}
 }
 
-TensorLayout layoutFromView(const Tensor::View& v) { return v.getLayout(); }
-
 Tensor::Shape broadcastShapes(const Tensor::Shape& lhs, const Tensor::Shape& rhs) {
 	size_t rankLhs = lhs.getNumDims();
 	size_t rankRhs = rhs.getNumDims();
@@ -67,8 +65,8 @@ BinaryOpContext BinaryOpContext::build(const Tensor::View& lhs, const Tensor::Vi
 	Tensor::Shape outShape = broadcastShapes(lhs.getShape(), rhs.getShape());
 
 	BinaryOpContext ctx;
-	ctx.lhs = broadcastTo(layoutFromView(lhs), outShape);
-	ctx.rhs = broadcastTo(layoutFromView(rhs), outShape);
+	ctx.lhs = broadcastTo(lhs.getLayout(), outShape);
+	ctx.rhs = broadcastTo(rhs.getLayout(), outShape);
 	ctx.out = outShape.toContiguousLayout();
 	return ctx;
 }
@@ -132,8 +130,8 @@ MatmulContext MatmulContext::build(const Tensor::View& lhs, const Tensor::View& 
 	ctx.p = rhsShape.getDim(rhsRank - 1);
 	ctx.batch = computeBatch(lhsShape, rhsShape, lhsRank, rhsRank);
 
-	ctx.lhs = layoutFromView(lhs);
-	ctx.rhs = layoutFromView(rhs);
+	ctx.lhs = lhs.getLayout();
+	ctx.rhs = rhs.getLayout();
 	ctx.out = computeOutputLayout(ctx.batch, ctx.m, ctx.p);
 
 	return ctx;

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -2,12 +2,20 @@
 
 namespace semantic {
 
-void ensureSameBackend(const Tensor& lhs, const Tensor& rhs) {
-	if (lhs.getBackend() != rhs.getBackend()) {
+void ensureSameBackend(const Tensor::View& lhs, const Tensor::View& rhs) {
+	Backend lhsBackend = lhs.getParent().getBackend();
+	Backend rhsBackend = rhs.getParent().getBackend();
+
+	auto lhsBackendStr = lhs.getParent().getBackendString();
+	auto rhsBackendStr = rhs.getParent().getBackendString();
+
+	auto lhsShapeStr = lhs.getShape().toString();
+	auto rhsShapeStr = rhs.getShape().toString();
+
+	if (lhsBackend != rhsBackend) {
 		throw std::runtime_error(
-		    "Can not perform binary operation on tensor on different devices " +
-		    lhs.getBackendString() + " and " + rhs.getBackendString() + " of shapes " +
-		    lhs.getShape().toString() + " and " + rhs.getShape().toString());
+		    "Can not perform binary operation on tensor on different devices " + lhsBackendStr +
+		    " and " + rhsBackendStr + " of shapes " + lhsShapeStr + " and " + rhsShapeStr);
 	}
 }
 
@@ -65,7 +73,7 @@ static TensorLayout broadcastTo(TensorLayout src, const Tensor::Shape& target) {
 }
 
 BinaryOpContext BinaryOpContext::build(const Tensor::View& lhs, const Tensor::View& rhs) {
-	ensureSameBackend(lhs.getParent(), rhs.getParent());
+	ensureSameBackend(lhs, rhs);
 
 	Tensor::Shape outShape = broadcastShapes(lhs.getShape(), rhs.getShape());
 
@@ -121,7 +129,7 @@ IndexContext IndexContext::build(const Tensor::View& src, size_t idx) {
 }
 
 MatmulContext MatmulContext::build(const Tensor::View& lhs, const Tensor::View& rhs) {
-	ensureSameBackend(lhs.getParent(), rhs.getParent());
+	ensureSameBackend(lhs, rhs);
 
 	Tensor::Shape lhsShape = lhs.getShape();
 	Tensor::Shape rhsShape = rhs.getShape();

--- a/src/ops/semantic/semantic.h
+++ b/src/ops/semantic/semantic.h
@@ -65,6 +65,13 @@ struct MatmulContext {
 
 private:
 	MatmulContext() = default;  // enforce use of build
+
+	static void validateRanks(size_t lhsRank, size_t rhsRank);
+	static void validateInnerDims(const Tensor::Shape& lhsShape, const Tensor::Shape& rhsShape,
+	                              size_t lhsRank, size_t rhsRank);
+	static size_t computeBatch(const Tensor::Shape& lhsShape, const Tensor::Shape& rhsShape,
+	                           size_t lhsRank, size_t rhsRank);
+	static TensorLayout computeOutputLayout(size_t batch, size_t m, size_t p);
 };
 
 }  // namespace semantic

--- a/src/ops/semantic/semantic.h
+++ b/src/ops/semantic/semantic.h
@@ -8,53 +8,53 @@
 
 namespace semantic {
 
-struct BinaryOpContext {
-	static BinaryOpContext build(const Tensor::View& lhs, const Tensor::View& rhs);
+namespace detail {
+// forces all contexts to use build method.
+class OperationContext {
+protected:
+	OperationContext() = default;
+};
+}  // namespace detail
 
+
+class BinaryOpContext : detail::OperationContext {
+public:
 	TensorLayout lhs;
 	TensorLayout rhs;
 	TensorLayout out;
 
-private:
-	BinaryOpContext() = default;  // enforce use of build
+	static BinaryOpContext build(const Tensor::View& lhs, const Tensor::View& rhs);
 };
 
-struct InplaceBinaryOpContext {
-	static InplaceBinaryOpContext build(const Tensor::View& lhs, const Tensor::View& rhs);
-
+class InplaceBinaryOpContext : detail::OperationContext {
+public:
 	TensorLayout lhs;
 	TensorLayout rhs;
 
-private:
-	InplaceBinaryOpContext() = default;  // enforce use of build
+	static InplaceBinaryOpContext build(const Tensor::View& lhs, const Tensor::View& rhs);
 };
 
 
-struct ReductionContext {
-	static ReductionContext build(const Tensor::View& lhs, size_t dim);
-
+class ReductionContext : detail::OperationContext {
+public:
 	TensorLayout lhs;
 	TensorLayout out;
 	TensorLayout block;
 
-private:
-	ReductionContext() = default;  // enforce use of build
+	static ReductionContext build(const Tensor::View& lhs, size_t dim);
 };
 
 
-struct IndexContext {
-	static IndexContext build(const Tensor::View& src, size_t idx);
-
+class IndexContext : detail::OperationContext {
+public:
 	TensorLayout out;
 
-private:
-	IndexContext() = default;  // enforce use of build
+	static IndexContext build(const Tensor::View& src, size_t idx);
 };
 
 
-struct MatmulContext {
-	static MatmulContext build(const Tensor::View& lhs, const Tensor::View& rhs);
-
+class MatmulContext : detail::OperationContext {
+public:
 	TensorLayout lhs;
 	TensorLayout rhs;
 	TensorLayout out;
@@ -63,15 +63,7 @@ struct MatmulContext {
 	size_t k;
 	size_t p;
 
-private:
-	MatmulContext() = default;  // enforce use of build
-
-	static void validateRanks(size_t lhsRank, size_t rhsRank);
-	static void validateInnerDims(const Tensor::Shape& lhsShape, const Tensor::Shape& rhsShape,
-	                              size_t lhsRank, size_t rhsRank);
-	static size_t computeBatch(const Tensor::Shape& lhsShape, const Tensor::Shape& rhsShape,
-	                           size_t lhsRank, size_t rhsRank);
-	static TensorLayout computeOutputLayout(size_t batch, size_t m, size_t p);
+	static MatmulContext build(const Tensor::View& lhs, const Tensor::View& rhs);
 };
 
 }  // namespace semantic

--- a/src/ops/semantic/semantic.h
+++ b/src/ops/semantic/semantic.h
@@ -9,27 +9,52 @@
 namespace semantic {
 
 struct BinaryOpContext {
+	static BinaryOpContext build(const Tensor::View& lhs, const Tensor::View& rhs);
+
 	TensorLayout lhs;
 	TensorLayout rhs;
 	TensorLayout out;
+
+private:
+	BinaryOpContext() = default;  // enforce use of build
 };
 
 struct InplaceBinaryOpContext {
+	static InplaceBinaryOpContext build(const Tensor::View& lhs, const Tensor::View& rhs);
+
 	TensorLayout lhs;
 	TensorLayout rhs;
+
+private:
+	InplaceBinaryOpContext() = default;  // enforce use of build
 };
 
+
 struct ReductionContext {
+	static ReductionContext build(const Tensor::View& lhs, size_t dim);
+
 	TensorLayout lhs;
 	TensorLayout out;
 	TensorLayout block;
+
+private:
+	ReductionContext() = default;  // enforce use of build
 };
+
 
 struct IndexContext {
+	static IndexContext build(const Tensor::View& src, size_t idx);
+
 	TensorLayout out;
+
+private:
+	IndexContext() = default;  // enforce use of build
 };
 
+
 struct MatmulContext {
+	static MatmulContext build(const Tensor::View& lhs, const Tensor::View& rhs);
+
 	TensorLayout lhs;
 	TensorLayout rhs;
 	TensorLayout out;
@@ -37,22 +62,11 @@ struct MatmulContext {
 	size_t m;
 	size_t k;
 	size_t p;
+
+private:
+	MatmulContext() = default;  // enforce use of build
 };
 
-BinaryOpContext buildBinaryOpContext(const Tensor::View& lhs, const Tensor::View& rhs);
-BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs);
-
-ReductionContext buildReductionContext(const Tensor::View& lhs, size_t dim);
-ReductionContext validateReduction(const Tensor::View& lhs, size_t dim);
-
-IndexContext buildIndexContext(const Tensor::View& src, size_t idx);
-IndexContext validateIndexing(const Tensor::View& src, size_t idx);
-
-MatmulContext buildMatmulContext(const Tensor::View& lhs, const Tensor::View& rhs);
-MatmulContext validateMatmul(const Tensor::View& lhs, const Tensor::View& rhs);
-
-InplaceBinaryOpContext validateInplaceBinaryOperation(const Tensor::View& lhs,
-                                                      const Tensor::View& rhs);
 }  // namespace semantic
 
 #endif  // SEMANTIC_H

--- a/src/ops/semantic/semantic.h
+++ b/src/ops/semantic/semantic.h
@@ -29,16 +29,27 @@ struct IndexContext {
 	TensorLayout out;
 };
 
+struct MatmulContext {
+	TensorLayout lhs;
+	TensorLayout rhs;
+	TensorLayout out;
+	size_t batch;
+	size_t m;
+	size_t k;
+	size_t p;
+};
+
 BinaryOpContext buildContext(const Tensor::View& lhs, const Tensor::View& rhs);
 ReductionContext buildReductionContext(const Tensor::View& lhs, size_t dim);
 IndexContext buildIndexContext(const Tensor::View& src, size_t idx);
+MatmulContext buildMatmulContext(const Tensor::View& lhs, const Tensor::View& rhs);
 
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs);
 InplaceBinaryOpContext validateInplaceBinaryOperation(const Tensor::View& lhs,
                                                       const Tensor::View& rhs);
 ReductionContext validateReduction(const Tensor::View& lhs, size_t dim);
 IndexContext validateIndexing(const Tensor::View& src, size_t idx);
-
+MatmulContext validateMatmul(const Tensor::View& lhs, const Tensor::View& rhs);
 }  // namespace semantic
 
 #endif  // SEMANTIC_H

--- a/src/ops/semantic/semantic.h
+++ b/src/ops/semantic/semantic.h
@@ -39,17 +39,20 @@ struct MatmulContext {
 	size_t p;
 };
 
-BinaryOpContext buildContext(const Tensor::View& lhs, const Tensor::View& rhs);
-ReductionContext buildReductionContext(const Tensor::View& lhs, size_t dim);
-IndexContext buildIndexContext(const Tensor::View& src, size_t idx);
-MatmulContext buildMatmulContext(const Tensor::View& lhs, const Tensor::View& rhs);
-
+BinaryOpContext buildBinaryOpContext(const Tensor::View& lhs, const Tensor::View& rhs);
 BinaryOpContext validateBinaryOperation(const Tensor::View& lhs, const Tensor::View& rhs);
+
+ReductionContext buildReductionContext(const Tensor::View& lhs, size_t dim);
+ReductionContext validateReduction(const Tensor::View& lhs, size_t dim);
+
+IndexContext buildIndexContext(const Tensor::View& src, size_t idx);
+IndexContext validateIndexing(const Tensor::View& src, size_t idx);
+
+MatmulContext buildMatmulContext(const Tensor::View& lhs, const Tensor::View& rhs);
+MatmulContext validateMatmul(const Tensor::View& lhs, const Tensor::View& rhs);
+
 InplaceBinaryOpContext validateInplaceBinaryOperation(const Tensor::View& lhs,
                                                       const Tensor::View& rhs);
-ReductionContext validateReduction(const Tensor::View& lhs, size_t dim);
-IndexContext validateIndexing(const Tensor::View& src, size_t idx);
-MatmulContext validateMatmul(const Tensor::View& lhs, const Tensor::View& rhs);
 }  // namespace semantic
 
 #endif  // SEMANTIC_H

--- a/tests/unit/test_arithmetic.cpp
+++ b/tests/unit/test_arithmetic.cpp
@@ -119,3 +119,104 @@ TEST_CASE("In-place division operator", "[Tensor][Arithmetic]") {
 		REQUIRE(a == Tensor({3}, 1.5f, backend));
 	}
 }
+
+TEST_CASE("Matrix multiplication basic 2D", "[Tensor][Matmul]") {
+	auto backend = GENERATE(from_range(backends));
+
+	DYNAMIC_SECTION(getBackendString(backend)) {
+		// A (2x3) * B (3x2) = C (2x2)
+		Tensor A({2, 3}, 1.0f, backend);
+		Tensor B({3, 2}, 2.0f, backend);
+
+		Tensor C = A.matmul(B);
+
+		// each element = 1*2 + 1*2 + 1*2 = 6
+		REQUIRE(C == Tensor({2, 2}, 6.0f, backend));
+	}
+}
+
+TEST_CASE("Matrix multiplication inner dimension mismatch throws", "[Tensor][Matmul]") {
+	auto backend = GENERATE(from_range(backends));
+
+	DYNAMIC_SECTION(getBackendString(backend)) {
+		Tensor A({2, 3}, 1.0f, backend);
+		Tensor B({4, 2}, 1.0f, backend);
+
+		REQUIRE_THROWS(A.matmul(B));
+	}
+}
+
+TEST_CASE("Matrix multiplication batched 3D", "[Tensor][Matmul]") {
+	auto backend = GENERATE(from_range(backends));
+
+	DYNAMIC_SECTION(getBackendString(backend)) {
+		// A (2x2x3) * B (2x3x2) = C (2x2x2)
+		Tensor A({2, 2, 3}, 1.0f, backend);
+		Tensor B({2, 3, 2}, 2.0f, backend);
+
+		Tensor C = A.matmul(B);
+
+		// each element = 1*2 + 1*2 + 1*2 = 6
+		REQUIRE(C == Tensor({2, 2, 2}, 6.0f, backend));
+	}
+}
+
+TEST_CASE("Matrix multiplication batched vs non-batched", "[Tensor][Matmul]") {
+	auto backend = GENERATE(from_range(backends));
+
+	DYNAMIC_SECTION(getBackendString(backend)) {
+		Tensor A({2, 2, 3}, 1.0f, backend);
+		Tensor B({3, 2}, 2.0f, backend);
+
+		Tensor C = A.matmul(B);
+
+		REQUIRE(C == Tensor({2, 2, 2}, 6.0f, backend));
+	}
+}
+
+TEST_CASE("Matrix multiplication mismatched batch throws", "[Tensor][Matmul]") {
+	auto backend = GENERATE(from_range(backends));
+
+	DYNAMIC_SECTION(getBackendString(backend)) {
+		Tensor A({2, 2, 3}, 1.0f, backend);
+		Tensor B({3, 3, 2}, 1.0f, backend);
+
+		REQUIRE_THROWS(A.matmul(B));
+	}
+}
+
+TEST_CASE("Matrix multiplication invalid rank throws", "[Tensor][Matmul]") {
+	auto backend = GENERATE(from_range(backends));
+
+	DYNAMIC_SECTION(getBackendString(backend)) {
+		Tensor A({3}, 1.0f, backend);
+		Tensor B({3, 2}, 1.0f, backend);
+
+		REQUIRE_THROWS(A.matmul(B));
+	}
+}
+
+TEST_CASE("Matrix multiplication non-uniform values", "[Tensor][Matmul]") {
+	auto backend = GENERATE(from_range(backends));
+
+	DYNAMIC_SECTION(getBackendString(backend)) {
+		Tensor A({2, 2}, 0.0f, backend);
+		A[0][0] = 1.0f;
+		A[0][1] = 2.0f;
+		A[1][0] = 3.0f;
+		A[1][1] = 4.0f;
+
+		Tensor B({2, 2}, 0.0f, backend);
+		B[0][0] = 5.0f;
+		B[0][1] = 6.0f;
+		B[1][0] = 7.0f;
+		B[1][1] = 8.0f;
+
+		Tensor C = A.matmul(B);
+
+		REQUIRE(C[0][0] == Tensor(19.0f, backend));
+		REQUIRE(C[0][1] == Tensor(22.0f, backend));
+		REQUIRE(C[1][0] == Tensor(43.0f, backend));
+		REQUIRE(C[1][1] == Tensor(50.0f, backend));
+	}
+}

--- a/tests/unit/test_semantic.cpp
+++ b/tests/unit/test_semantic.cpp
@@ -7,7 +7,7 @@
 TEST_CASE("Tensor vs Tensor", "[Semantic]") {
 	Tensor a({3}, 4.0f, Backend::CPU), b({3}, 4.0f, Backend::CPU);
 
-	auto ctx = semantic::validateBinaryOperation(a, b);
+	auto ctx = semantic::BinaryOpContext::build(a, b);
 
 	REQUIRE(ctx.lhs.offset == 0);
 	REQUIRE(ctx.rhs.offset == 0);
@@ -21,7 +21,7 @@ TEST_CASE("Tensor view vs Tensor view", "[Semantic]") {
 	Tensor::View x = a[4];
 	Tensor::View y = b[9];
 
-	auto ctx = semantic::validateBinaryOperation(x, y);
+	auto ctx = semantic::BinaryOpContext::build(x, y);
 
 	REQUIRE(ctx.lhs.offset == 8 * 4);
 	REQUIRE(ctx.rhs.offset == 8 * 9);
@@ -35,7 +35,7 @@ TEST_CASE("Tensor vs View", "[Semantic]") {
 
 	Tensor::View v = a[4];
 
-	auto ctx = semantic::validateBinaryOperation(b, v);
+	auto ctx = semantic::BinaryOpContext::build(b, v);
 
 	REQUIRE(ctx.lhs.offset == 0);
 	REQUIRE(ctx.rhs.offset == 8 * 4);
@@ -49,7 +49,7 @@ TEST_CASE("View vs Tensor", "[Semantic]") {
 
 	Tensor::View v = a[6];
 
-	auto ctx = semantic::validateBinaryOperation(v, b);
+	auto ctx = semantic::BinaryOpContext::build(v, b);
 
 	REQUIRE(ctx.lhs.offset == 8 * 6);
 	REQUIRE(ctx.rhs.offset == 0);
@@ -61,7 +61,7 @@ TEST_CASE("Scalar vs Tensor shape", "[Semantic]") {
 	Tensor a({3, 4}, 1.0f, Backend::CPU);
 	Tensor b({1}, 2.0f, Backend::CPU);
 
-	auto ctx = semantic::validateBinaryOperation(a, b);
+	auto ctx = semantic::BinaryOpContext::build(a, b);
 
 	REQUIRE(ctx.lhs.offset == 0);
 	REQUIRE(ctx.rhs.offset == 0);
@@ -79,7 +79,7 @@ TEST_CASE("Scalar vs Tensor view", "[Semantic]") {
 
 	Tensor::View v = b[2];
 
-	auto ctx = semantic::validateBinaryOperation(a, v);
+	auto ctx = semantic::BinaryOpContext::build(a, v);
 
 	REQUIRE(ctx.lhs.offset == 0);
 	REQUIRE(ctx.rhs.offset == 2 * 8 * 4);
@@ -95,7 +95,7 @@ TEST_CASE("Broadcast (3,1) and (1,4) -> (3,4)", "[Semantic]") {
 	Tensor a({3, 1}, 1.0f, Backend::CPU);
 	Tensor b({1, 4}, 1.0f, Backend::CPU);
 
-	auto ctx = semantic::validateBinaryOperation(a, b);
+	auto ctx = semantic::BinaryOpContext::build(a, b);
 
 	REQUIRE(ctx.out.rank == 2);
 	REQUIRE(ctx.out.shape[0] == 3);
@@ -109,7 +109,7 @@ TEST_CASE("Single element vs Tensor broadcasts", "[Semantic]") {
 	Tensor a({1, 1}, 1.0f, Backend::CPU);
 	Tensor b({3, 4}, 1.0f, Backend::CPU);
 
-	auto ctx = semantic::validateBinaryOperation(a, b);
+	auto ctx = semantic::BinaryOpContext::build(a, b);
 
 	REQUIRE(ctx.out.shape[0] == 3);
 	REQUIRE(ctx.out.shape[1] == 4);
@@ -121,8 +121,8 @@ TEST_CASE("Single element vs Tensor broadcasts", "[Semantic]") {
 TEST_CASE("Throw on tensor device mismatch", "[Semantic]") {
 	Tensor a({3}, 4.0f, Backend::CPU), b({3}, 4.0f, Backend::CUDA);
 
-	REQUIRE_THROWS_AS(semantic::validateBinaryOperation(a, b), std::runtime_error);
-	CHECK_THROWS_WITH(semantic::validateBinaryOperation(a, b),
+	REQUIRE_THROWS_AS(semantic::BinaryOpContext::build(a, b), std::runtime_error);
+	CHECK_THROWS_WITH(semantic::BinaryOpContext::build(a, b),
 	                  Catch::Matchers::ContainsSubstring("different devices"));
 }
 
@@ -132,8 +132,8 @@ TEST_CASE("Throw on tensor view device mismatch", "[Semantic]") {
 	Tensor::View x = a[0];
 	Tensor::View y = b[0];
 
-	REQUIRE_THROWS_AS(semantic::validateBinaryOperation(x, y), std::runtime_error);
-	CHECK_THROWS_WITH(semantic::validateBinaryOperation(x, y),
+	REQUIRE_THROWS_AS(semantic::BinaryOpContext::build(x, y), std::runtime_error);
+	CHECK_THROWS_WITH(semantic::BinaryOpContext::build(x, y),
 	                  Catch::Matchers::ContainsSubstring("different devices"));
 }
 #endif  // NFORGE_WITH_CUDA
@@ -146,7 +146,7 @@ TEST_CASE("Reduction operation", "[Semantic]") {
 	// Block to reduce = {3, 5}
 	// Resulting shape = {1}
 
-	auto ctx = semantic::validateReduction(a, dim);
+	auto ctx = semantic::ReductionContext::build(a, dim);
 
 	REQUIRE(ctx.out.shape[0] == 1);
 	REQUIRE(ctx.block.shape[0] == 3);
@@ -156,6 +156,6 @@ TEST_CASE("Reduction operation", "[Semantic]") {
 TEST_CASE("Throw on invalid dim in reduction operation", "[Semantic]") {
 	Tensor a({1, 3, 5}, 1.0f, Backend::CPU);
 
-	REQUIRE_THROWS(semantic::validateReduction(a, -1));
-	REQUIRE_THROWS(semantic::validateReduction(a, 4));
+	REQUIRE_THROWS(semantic::ReductionContext::build(a, -1));
+	REQUIRE_THROWS(semantic::ReductionContext::build(a, 4));
 }


### PR DESCRIPTION
## Summary

- Implements `.matmul()` for `Tensor`'s and `View`'s 
- Unified Function Call Syntax (UFCS) meaning `nforge::matmul(A, B)` is equivalent to `A.matmul(B)`.
- Refactor semantic context API