### PR TITLE
perf: move unnecessary string construction

### DIFF
--- a/include/nforge/core/tensor.h
+++ b/include/nforge/core/tensor.h
@@ -51,7 +51,7 @@ public:
 	std::string getBackendString() const;
 
 	// Returns backend enum
-	Backend getBackend() const;
+	inline Backend getBackend() const { return m_backend; }
 
 	// Returns the data of the tensor as a string
 	std::string getDataString() const;

--- a/include/nforge/core/tensor_view.h
+++ b/include/nforge/core/tensor_view.h
@@ -19,22 +19,22 @@ public:
 	void print() const;
 
 	// referenced tensor
-	Tensor& getParent() const;
+	inline Tensor& getParent() const { return m_parent; }
 
 	// position of this view in the tensor it references
-	std::vector<size_t> getPosition() const;
+	inline std::vector<size_t> getPosition() const { return m_position; }
 
 	// number of elements preceding this view
-	size_t getOffset() const;
+	inline size_t getOffset() const { return m_layout.offset; }
 
 	// shape of the view
-	Tensor::Shape getShape() const;
+	inline Tensor::Shape getShape() const { return Tensor::Shape(m_layout); }
 
 	// returns the stride for each dim, not the underlying stride
 	std::vector<size_t> getStride() const;
 
 	// returns the underlying physical layout
-	const TensorLayout& getLayout() const;
+	const TensorLayout& getLayout() const { return m_layout; }
 
 	// creates a copy of the viewed tensor
 	Tensor copy() const;

--- a/src/core/tensor.cpp
+++ b/src/core/tensor.cpp
@@ -71,8 +71,6 @@ std::string Tensor::getBackendString() const {
 	}
 }
 
-Backend Tensor::getBackend() const { return m_backend; }
-
 std::string Tensor::getDataString() const { return m_impl->toString(); }
 
 size_t Tensor::getNumElements() const { return m_impl->getNumElements(); }

--- a/src/core/tensor_view.cpp
+++ b/src/core/tensor_view.cpp
@@ -72,16 +72,6 @@ void Tensor::View::print() const {
 	m_parent.print(position);
 }
 
-Tensor& Tensor::View::getParent() const { return m_parent; }
-
-std::vector<size_t> Tensor::View::getPosition() const { return m_position; }
-
-size_t Tensor::View::getOffset() const { return m_layout.offset; }
-
-Tensor::Shape Tensor::View::getShape() const { return Tensor::Shape(m_layout); }
-
-const TensorLayout& Tensor::View::getLayout() const { return m_layout; }
-
 std::vector<size_t> Tensor::View::getStride() const {
 	std::vector<size_t> stride(m_layout.strides.begin(), m_layout.strides.begin() + m_layout.rank);
 	std::vector<size_t> baseStride = m_parent.getShape().getContiguousStrides();

--- a/src/ops/semantic/semantic.cpp
+++ b/src/ops/semantic/semantic.cpp
@@ -3,16 +3,13 @@
 namespace semantic {
 
 void ensureSameBackend(const Tensor::View& lhs, const Tensor::View& rhs) {
-	Backend lhsBackend = lhs.getParent().getBackend();
-	Backend rhsBackend = rhs.getParent().getBackend();
+	if (lhs.getParent().getBackend() != rhs.getParent().getBackend()) {
+		const auto& lhsBackendStr = lhs.getParent().getBackendString();
+		const auto& rhsBackendStr = rhs.getParent().getBackendString();
 
-	auto lhsBackendStr = lhs.getParent().getBackendString();
-	auto rhsBackendStr = rhs.getParent().getBackendString();
+		const auto& lhsShapeStr = lhs.getShape().toString();
+		const auto& rhsShapeStr = rhs.getShape().toString();
 
-	auto lhsShapeStr = lhs.getShape().toString();
-	auto rhsShapeStr = rhs.getShape().toString();
-
-	if (lhsBackend != rhsBackend) {
 		throw std::runtime_error(
 		    "Can not perform binary operation on tensor on different devices " + lhsBackendStr +
 		    " and " + rhsBackendStr + " of shapes " + lhsShapeStr + " and " + rhsShapeStr);


### PR DESCRIPTION
## Summary

- Performance regression seen after #56
- Likely due to unnecessary string copy in ensureSameBackend, which is called for every binary operation.